### PR TITLE
Use context.Context when possibl to handle the registration, no more struct{} channel

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# v7.0.0
+
+* Use context.Context to handle lifecycle of the registration
+
 # v6.0.2
 
 * Fix: Auto-fill wont work if the hostname exists

--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ API
 /*
  * First argument is the name of the service
  * Then a struct containing the service informations
- * The stop channel exists if you want to be able to stop the registeration
+ * The registeration will stop when the context will be canceled.
  * It will return the service uuid and a channel which will send back any modifications made to the service by the other host of the same service. This is usefull for credential synchronisation.
  */
-stopper := make(chan struct{})
+ctx, cancel := context.WithCancel(context.Background())
 registration := service.Register(
+  ctx,
   "my-service",
   &service.Host{
     Hostname: "public-domain.dev",
@@ -39,7 +40,7 @@ registration := service.Register(
       "http":  "8080",
       "https": "80443",
     },
-  }, stopper)
+  })
 ```
 
 This will create two different etcd keys:

--- a/service/get_test.go
+++ b/service/get_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -19,12 +20,13 @@ func TestGetNoHost(t *testing.T) {
 
 func TestGet(t *testing.T) {
 	Convey("With registred services", t, func() {
-		stop1, stop2 := make(chan struct{}), make(chan struct{})
+		ctx1, cancel1 := context.WithCancel(context.Background())
+		ctx2, cancel2 := context.WithCancel(context.Background())
 		host1, host2 := genHost("host1"), genHost("host2")
 		host1.Name = "test_service_get"
 		host2.Name = "test_service_get"
-		w1 := Register("test_service_get", host1, stop1)
-		w2 := Register("test_service_get", host2, stop2)
+		w1 := Register(ctx1, "test_service_get", host1)
+		w2 := Register(ctx2, "test_service_get", host2)
 		w1.WaitRegistration()
 		w2.WaitRegistration()
 		Convey("We should have 2 hosts", func() {
@@ -44,8 +46,8 @@ func TestGet(t *testing.T) {
 			}
 			So(err, ShouldBeNil)
 		})
-		close(stop1)
-		close(stop2)
+		cancel1()
+		cancel2()
 	})
 }
 

--- a/service/registration_test.go
+++ b/service/registration_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -9,7 +10,7 @@ import (
 
 func TestRegistrationReady(t *testing.T) {
 	Convey("When a new registration is created", t, func() {
-		r := NewRegistration("1234", make(chan Credentials))
+		r := NewRegistration(context.Background(), "1234", make(chan Credentials))
 		Convey("it must send false", func() {
 			So(r.Ready(), ShouldBeFalse)
 		})
@@ -17,7 +18,7 @@ func TestRegistrationReady(t *testing.T) {
 
 	Convey("After a service registration", t, func() {
 		cred := make(chan Credentials)
-		r := NewRegistration("1234", cred)
+		r := NewRegistration(context.Background(), "1234", cred)
 		cred <- Credentials{
 			User:     "Moi",
 			Password: "Lui",
@@ -33,7 +34,7 @@ func TestWaitRegistration(t *testing.T) {
 	Convey("It must wait for a service registration", t, func() {
 		order := make([]bool, 2)
 		cred := make(chan Credentials)
-		r := NewRegistration("1234", cred)
+		r := NewRegistration(context.Background(), "1234", cred)
 		registrationChan := make(chan bool)
 		go func() {
 			for {
@@ -64,14 +65,14 @@ func TestWaitRegistration(t *testing.T) {
 
 func TestUUID(t *testing.T) {
 	Convey("It must send the original UUID", t, func() {
-		r := NewRegistration("test-test-123", make(chan Credentials))
+		r := NewRegistration(context.Background(), "test-test-123", make(chan Credentials))
 		So(r.UUID(), ShouldEqual, "test-test-123")
 	})
 }
 
 func TestCredentials(t *testing.T) {
 	Convey("Before a service registration", t, func() {
-		r := NewRegistration("test", make(chan Credentials))
+		r := NewRegistration(context.Background(), "test", make(chan Credentials))
 		Convey("It should return an error", func() {
 			_, err := r.Credentials()
 			So(err, ShouldNotBeNil)
@@ -81,7 +82,7 @@ func TestCredentials(t *testing.T) {
 
 	Convey("After a service registration", t, func() {
 		cred := make(chan Credentials)
-		r := NewRegistration("test", cred)
+		r := NewRegistration(context.Background(), "test", cred)
 		cred <- Credentials{
 			User:     "1",
 			Password: "2",
@@ -97,7 +98,7 @@ func TestCredentials(t *testing.T) {
 
 	Convey("After a credential update", t, func() {
 		cred := make(chan Credentials)
-		r := NewRegistration("test", cred)
+		r := NewRegistration(context.Background(), "test", cred)
 		cred <- Credentials{
 			User:     "1",
 			Password: "2",

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -19,8 +20,8 @@ func TestServiceAll(t *testing.T) {
 	Convey("With two services", t, func() {
 		host1 := genHost("test1")
 		host2 := genHost("test2")
-		w1 := Register("test-get-222", host1, make(chan struct{}))
-		w2 := Register("test-get-222", host2, make(chan struct{}))
+		w1 := Register(context.Background(), "test-get-222", host1)
+		w2 := Register(context.Background(), "test-get-222", host2)
 
 		w1.WaitRegistration()
 		w2.WaitRegistration()
@@ -50,7 +51,7 @@ func TestServiceFirst(t *testing.T) {
 
 	Convey("With a service", t, func() {
 		host1 := genHost("test1")
-		w := Register("test-truc", host1, make(chan struct{}))
+		w := Register(context.Background(), "test-truc", host1)
 		w.WaitRegistration()
 
 		s, err := Get("test-truc").Service()
@@ -74,7 +75,7 @@ func TestServiceOne(t *testing.T) {
 
 	Convey("With a service", t, func() {
 		host1 := genHost("test1")
-		w := Register("test-truc", host1, make(chan struct{}))
+		w := Register(context.Background(), "test-truc", host1)
 		w.WaitRegistration()
 
 		s, err := Get("test-truc").Service()
@@ -92,7 +93,7 @@ func TestServiceUrl(t *testing.T) {
 			host := genHost("test")
 			host.User = ""
 			host.Password = ""
-			w := Register("service-url-1", host, make(chan struct{}))
+			w := Register(context.Background(), "service-url-1", host)
 			w.WaitRegistration()
 
 			s, err := Get("service-url-1").Service()
@@ -104,7 +105,7 @@ func TestServiceUrl(t *testing.T) {
 
 		Convey("With a host with a password", func() {
 			host := genHost("test")
-			w := Register("service-url-3", host, make(chan struct{}))
+			w := Register(context.Background(), "service-url-3", host)
 			w.WaitRegistration()
 
 			s, err := Get("service-url-3").Service()
@@ -116,7 +117,7 @@ func TestServiceUrl(t *testing.T) {
 
 		Convey("When the port does'nt exists", func() {
 			host := genHost("test")
-			w := Register("service-url-4", host, make(chan struct{}))
+			w := Register(context.Background(), "service-url-4", host)
 			w.WaitRegistration()
 
 			s, err := Get("service-url-4").Service()


### PR DESCRIPTION
Fixes #33