### PR TITLE
chore(README): fix go get command used for etcd-discovery installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a golang package for managing services over the decentralized key-value 
 
 To install it:
 
-`go get github.com/Scalingo/etcd-discovery/service/v7`
+`go get github.com/Scalingo/etcd-discovery/v7/service`
 
 ## API
 


### PR DESCRIPTION
Related to [SRE-620], version should be before package name

[SRE-620]: https://scalingo.atlassian.net/browse/SRE-620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ