### PR TITLE
refactor(lib): Migrate from errgo to go-utils/errors/v3, init context/logger and set-up gomock properly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Scalingo/etcd-discovery/v7
 go 1.25.0
 
 require (
+	github.com/Scalingo/go-utils/errors/v3 v3.2.1
 	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/stretchr/testify v1.11.1
 	go.etcd.io/etcd/client/pkg/v3 v3.6.10
@@ -14,7 +15,6 @@ require (
 	// The package "go.etcd.io/etcd/client/v3" is a complete refactoring
 	// of the client and uses grpc instead of http, that we currently use.
 	go.etcd.io/etcd/client/v2 v2.305.29
-	gopkg.in/errgo.v1 v1.0.1
 	go.uber.org/mock v0.6.0
 )
 
@@ -25,10 +25,12 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.etcd.io/etcd/api/v3 v3.6.10 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect
 	golang.org/x/sys v0.42.0 // indirect
+	gopkg.in/errgo.v1 v1.0.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Scalingo/go-utils/errors/v3 v3.2.1 h1:2w3qUz6MxJa3aqx/biz2G3JquSKsFnfz/E7wrNf/LPc=
+github.com/Scalingo/go-utils/errors/v3 v3.2.1/go.mod h1:jVVNoOdYFjuNkR/BeEZWNWJVvu4jmyLY4udlsQQyBss=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -25,6 +27,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/service/get_test.go
+++ b/service/get_test.go
@@ -2,7 +2,7 @@ package service
 
 import (
 	"context"
-	"errors"
+	stderrors "errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,7 +18,7 @@ func TestGetNoHost(t *testing.T) {
 
 	t.Run("Without any service, Get().One().Host() should return ErrNoServiceFound", func(t *testing.T) {
 		host, err := Get(t.Context(), "test_no_service").One(t.Context()).Host(t.Context())
-		require.EqualError(t, err, ErrNoServiceFound.Error())
+		require.ErrorContains(t, err, ErrNoServiceFound.Error())
 		assert.Nil(t, host)
 	})
 }
@@ -61,7 +61,7 @@ func TestGetServiceResponse(t *testing.T) {
 	t.Run("With an errored Response", func(t *testing.T) {
 		testErrorMsg := "my test error"
 		response := &GetServiceResponse{
-			err:     errors.New(testErrorMsg),
+			err:     stderrors.New(testErrorMsg),
 			service: nil,
 		}
 
@@ -132,12 +132,12 @@ func TestGetServiceResponse(t *testing.T) {
 
 		t.Run("One should pass the One error", func(t *testing.T) {
 			r := response.One(t.Context())
-			require.EqualError(t, r.Err(), ErrNoServiceFound.Error())
+			require.ErrorContains(t, r.Err(), ErrNoServiceFound.Error())
 		})
 
 		t.Run("First should pass the First error", func(t *testing.T) {
 			r := response.First(t.Context())
-			require.EqualError(t, r.Err(), "fetch hosts: "+ErrNoServiceFound.Error())
+			require.ErrorContains(t, r.Err(), ErrNoServiceFound.Error())
 		})
 	})
 }
@@ -190,15 +190,15 @@ func TestGetForShard(t *testing.T) {
 		assert.Nil(t, hosts)
 
 		emptyHost, err := GetForShard(t.Context(), "test_service_get_for_shard_no_match", testShard1ID).First(t.Context()).Host(t.Context())
-		require.EqualError(t, err, "fetch hosts: "+ErrNoHostFoundOnShard.Error())
+		require.ErrorContains(t, err, ErrNoHostFoundOnShard.Error())
 		assert.Nil(t, emptyHost)
 
 		oneHost, err := GetForShard(t.Context(), "test_service_get_for_shard_no_match", testShard1ID).One(t.Context()).Host(t.Context())
-		require.EqualError(t, err, ErrNoHostFoundOnShard.Error())
+		require.ErrorContains(t, err, ErrNoHostFoundOnShard.Error())
 		assert.Nil(t, oneHost)
 
 		url, err := GetForShard(t.Context(), "test_service_get_for_shard_no_match", testShard1ID).URL(t.Context(), "http", "/path")
-		require.EqualError(t, err, ErrNoHostFoundOnShard.Error())
+		require.ErrorContains(t, err, ErrNoHostFoundOnShard.Error())
 		assert.Empty(t, url)
 	})
 }

--- a/service/host.go
+++ b/service/host.go
@@ -2,11 +2,11 @@ package service
 
 import (
 	"context"
-	"errors"
+	stderrors "errors"
 	"fmt"
 	"strings"
 
-	"gopkg.in/errgo.v1"
+	"github.com/Scalingo/go-utils/errors/v3"
 )
 
 // Ports is a representation of the ports exposed by a host or a service.
@@ -76,12 +76,12 @@ func (h *Host) URL(ctx context.Context, scheme, path string) (string, error) {
 
 	if scheme != "" {
 		if port, ok = h.Ports[scheme]; !ok {
-			return "", errors.New("unknown scheme")
+			return "", ErrUnknownScheme
 		}
 	} else {
 		scheme, port, err = h.findSchemeAndPort(h.Ports)
 		if err != nil {
-			return "", errgo.Notef(err, "find scheme and port")
+			return "", errors.Wrap(ctx, err, "find scheme and port")
 		}
 	}
 
@@ -99,7 +99,7 @@ func (h *Host) PrivateURL(ctx context.Context, scheme, path string) (string, err
 	if h.PrivateHostname == "" {
 		url, err := h.URL(ctx, scheme, path)
 		if err != nil {
-			return "", errgo.Mask(err)
+			return "", errors.Wrap(ctx, err, "get public url")
 		}
 		return url, nil
 	}
@@ -113,12 +113,12 @@ func (h *Host) PrivateURL(ctx context.Context, scheme, path string) (string, err
 
 	if scheme != "" {
 		if port, ok = h.PrivatePorts[scheme]; !ok {
-			return "", errors.New("unknown scheme")
+			return "", ErrUnknownScheme
 		}
 	} else {
 		scheme, port, err = h.findSchemeAndPort(h.PrivatePorts)
 		if err != nil {
-			return "", errgo.Notef(err, "find scheme and port")
+			return "", errors.Wrap(ctx, err, "find scheme and port")
 		}
 	}
 
@@ -127,6 +127,7 @@ func (h *Host) PrivateURL(ctx context.Context, scheme, path string) (string, err
 	} else {
 		url = fmt.Sprintf("%s://%s:%s%s", scheme, h.PrivateHostname, port, path)
 	}
+
 	return url, nil
 }
 
@@ -137,7 +138,7 @@ func (h *Host) findSchemeAndPort(ports Ports) (string, string, error) {
 			return scheme, port, nil
 		}
 	}
-	return "", "", errors.New("scheme not found")
+	return "", "", stderrors.New("scheme not found")
 }
 
 // HostResponse is the interface used to provide a single host response.
@@ -168,7 +169,7 @@ func (q *GetHostResponse) Err() error {
 }
 
 // Host will return the host represented by this error.
-func (q *GetHostResponse) Host(ctx context.Context) (*Host, error) {
+func (q *GetHostResponse) Host(_ context.Context) (*Host, error) {
 	if q.err != nil {
 		return nil, q.err
 	}
@@ -181,9 +182,10 @@ func (q *GetHostResponse) URL(ctx context.Context, scheme, path string) (string,
 	if q.err != nil {
 		return "", q.err
 	}
+
 	url, err := q.host.URL(ctx, scheme, path)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(ctx, err, "get host public url")
 	}
 	return url, nil
 }
@@ -193,9 +195,10 @@ func (q *GetHostResponse) PrivateURL(ctx context.Context, scheme, path string) (
 	if q.err != nil {
 		return "", q.err
 	}
+
 	url, err := q.host.PrivateURL(ctx, scheme, path)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(ctx, err, "get host private url")
 	}
 	return url, nil
 }

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"errors"
+	stderrors "errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,7 +30,7 @@ func TestHostUrl(t *testing.T) {
 		host := genHost("test")
 		url, err := host.URL(t.Context(), "htjp", "/path")
 		require.Error(t, err)
-		assert.Equal(t, "unknown scheme", err.Error())
+		assert.ErrorIs(t, err, ErrUnknownScheme)
 		assert.Equal(t, 0, len(url))
 	})
 
@@ -64,7 +64,7 @@ func TestHostPrivateUrl(t *testing.T) {
 		host := genHost("test")
 		url, err := host.PrivateURL(t.Context(), "htjp", "/path")
 		require.Error(t, err)
-		assert.Equal(t, "unknown scheme", err.Error())
+		assert.ErrorIs(t, err, ErrUnknownScheme)
 		assert.Equal(t, 0, len(url))
 	})
 
@@ -102,7 +102,7 @@ func TestHostsString(t *testing.T) {
 func TestGetHostResponse(t *testing.T) {
 	t.Run("With an errored response", func(t *testing.T) {
 		response := &GetHostResponse{
-			err:  errors.New("TestError"),
+			err:  stderrors.New("TestError"),
 			host: nil,
 		}
 

--- a/service/init.go
+++ b/service/init.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
-	"errors"
+	stderrors "errors"
 	"fmt"
 	"log"
 	"net"
@@ -145,7 +145,7 @@ func tlsconfigFromMemory(certb64, keyb64, cab64 string) (*tls.Config, error) {
 
 	ca, _ := pem.Decode(capem)
 	if ca == nil {
-		return nil, errors.New("ca: invalid PEM")
+		return nil, stderrors.New("ca: invalid PEM")
 	}
 
 	certPool := x509.NewCertPool()

--- a/service/parser.go
+++ b/service/parser.go
@@ -5,7 +5,8 @@ import (
 	"encoding/json"
 
 	etcdv2 "go.etcd.io/etcd/client/v2"
-	"gopkg.in/errgo.v1"
+
+	"github.com/Scalingo/go-utils/errors/v3"
 )
 
 func buildHostsFromNodes(ctx context.Context, nodes etcdv2.Nodes) (Hosts, error) {
@@ -13,27 +14,27 @@ func buildHostsFromNodes(ctx context.Context, nodes etcdv2.Nodes) (Hosts, error)
 	for i, node := range nodes {
 		host, err := buildHostFromNode(ctx, node)
 		if err != nil {
-			return nil, errgo.Mask(err)
+			return nil, errors.Wrap(ctx, err, "build host from node")
 		}
 		hosts[i] = host
 	}
 	return hosts, nil
 }
 
-func buildHostFromNode(_ context.Context, node *etcdv2.Node) (*Host, error) {
+func buildHostFromNode(ctx context.Context, node *etcdv2.Node) (*Host, error) {
 	host := &Host{}
 	err := json.Unmarshal([]byte(node.Value), host)
 	if err != nil {
-		return nil, errgo.Notef(err, "Unable to unmarshal host")
+		return nil, errors.Wrap(ctx, err, "unmarshal host")
 	}
 	return host, nil
 }
 
-func buildServiceFromNode(_ context.Context, node *etcdv2.Node) (*Service, error) {
+func buildServiceFromNode(ctx context.Context, node *etcdv2.Node) (*Service, error) {
 	service := &Service{}
 	err := json.Unmarshal([]byte(node.Value), service)
 	if err != nil {
-		return nil, errgo.Notef(err, "Unable to unmarshal service")
+		return nil, errors.Wrap(ctx, err, "unmarshal service")
 	}
 	return service, nil
 }

--- a/service/register.go
+++ b/service/register.go
@@ -8,7 +8,8 @@ import (
 
 	"github.com/gofrs/uuid/v5"
 	etcdv2 "go.etcd.io/etcd/client/v2"
-	"gopkg.in/errgo.v1"
+
+	"github.com/Scalingo/go-utils/errors/v3"
 )
 
 const (
@@ -175,7 +176,7 @@ func watch(ctx context.Context, serviceKey string, id uint64, credentialsChan ch
 func hostRegistration(ctx context.Context, hostKey, hostJSON string) error {
 	_, err := KAPI().Set(ctx, hostKey, hostJSON, &etcdv2.SetOptions{TTL: HEARTBEAT_DURATION * time.Second})
 	if err != nil {
-		return errgo.Notef(err, "Unable to register host")
+		return errors.Wrap(ctx, err, "register host")
 	}
 	return nil
 }
@@ -211,7 +212,7 @@ func ensureHostRegistration(ctx context.Context, service, hostKey, hostJSON stri
 func serviceRegistration(ctx context.Context, serviceKey, serviceJSON string) (uint64, error) {
 	key, err := KAPI().Set(ctx, serviceKey, serviceJSON, nil)
 	if err != nil {
-		return 0, errgo.Notef(err, "Unable to register service")
+		return 0, errors.Wrap(ctx, err, "register service")
 	}
 
 	return key.Node.ModifiedIndex, nil

--- a/service/registration.go
+++ b/service/registration.go
@@ -2,7 +2,7 @@ package service
 
 import (
 	"context"
-	"errors"
+	stderrors "errors"
 	"sync"
 )
 
@@ -81,7 +81,7 @@ func (w *Registration) Credentials() (Credentials, error) {
 	cred := w.curCredentials
 	w.mutex.Unlock()
 	if cred == nil {
-		return Credentials{}, errors.New("Not ready")
+		return Credentials{}, stderrors.New("Not ready")
 	}
 	return *cred, nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -2,19 +2,20 @@ package service
 
 import (
 	"context"
-	"errors"
+	stderrors "errors"
 	"fmt"
 	"math/rand"
 
 	etcdv2 "go.etcd.io/etcd/client/v2"
-	"gopkg.in/errgo.v1"
+
+	"github.com/Scalingo/go-utils/errors/v3"
 )
 
 var (
-	ErrNoServiceFound     = errors.New("service not found")
-	ErrNoHostFound        = errors.New("no host found for this service")
-	ErrNoHostFoundOnShard = errors.New("no host found for this service on this shard")
-	ErrUnknownScheme      = errors.New("unknown scheme")
+	ErrNoServiceFound     = stderrors.New("service not found")
+	ErrNoHostFound        = stderrors.New("no host found for this service")
+	ErrNoHostFoundOnShard = stderrors.New("no host found for this service on this shard")
+	ErrUnknownScheme      = stderrors.New("unknown scheme")
 )
 
 // Service stores all the information about a service.
@@ -50,12 +51,12 @@ func (s *Service) All(ctx context.Context, queryOpts QueryOptions) (Hosts, error
 		if etcdv2.IsKeyNotFound(err) {
 			return nil, ErrNoServiceFound
 		}
-		return nil, errgo.Notef(err, "Unable to fetch services")
+		return nil, errors.Wrap(ctx, err, "fetch services")
 	}
 
 	hosts, err := buildHostsFromNodes(ctx, res.Node.Nodes)
 	if err != nil {
-		return nil, errgo.Mask(err)
+		return nil, errors.Wrap(ctx, err, "build hosts from nodes")
 	}
 
 	if len(hosts) == 0 {
@@ -86,7 +87,7 @@ func (s *Service) All(ctx context.Context, queryOpts QueryOptions) (Hosts, error
 func (s *Service) First(ctx context.Context, queryOpts QueryOptions) (*Host, error) {
 	hosts, err := s.All(ctx, queryOpts)
 	if err != nil {
-		return nil, errgo.Notef(err, "fetch hosts")
+		return nil, errors.Wrap(ctx, err, "fetch all hosts")
 	}
 
 	return hosts[0], nil
@@ -96,7 +97,7 @@ func (s *Service) First(ctx context.Context, queryOpts QueryOptions) (*Host, err
 func (s *Service) One(ctx context.Context, queryOpts QueryOptions) (*Host, error) {
 	hosts, err := s.All(ctx, queryOpts)
 	if err != nil {
-		return nil, errgo.Mask(err)
+		return nil, errors.Wrap(ctx, err, "fetch all hosts")
 	}
 
 	return hosts[rand.Int()%len(hosts)], nil
@@ -114,12 +115,12 @@ func (s *Service) URL(ctx context.Context, scheme, path string, queryOpts QueryO
 	if !s.Public || queryOpts.Shard != "" {
 		host, err := s.One(ctx, queryOpts)
 		if err != nil {
-			return "", errgo.Mask(err)
+			return "", errors.Wrap(ctx, err, "fetch one host")
 		}
 
 		url, err := host.URL(ctx, scheme, path)
 		if err != nil {
-			return "", errgo.Mask(err)
+			return "", errors.Wrap(ctx, err, "fetch one host url")
 		}
 		return url, nil
 	}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -82,7 +82,7 @@ func TestServiceFirst(t *testing.T) {
 		require.NoError(t, err)
 
 		host, err := s.First(t.Context(), QueryOptions{})
-		require.EqualError(t, err, "fetch hosts: "+ErrNoServiceFound.Error())
+		require.ErrorContains(t, err, ErrNoServiceFound.Error())
 		assert.Nil(t, host)
 	})
 
@@ -131,7 +131,7 @@ func TestServiceFirst(t *testing.T) {
 		require.NoError(t, err)
 
 		host, err := s.First(t.Context(), QueryOptions{Shard: testShard2ID})
-		require.EqualError(t, err, "fetch hosts: "+ErrNoHostFoundOnShard.Error())
+		require.ErrorContains(t, err, ErrNoHostFoundOnShard.Error())
 		assert.Nil(t, host)
 	})
 }
@@ -142,7 +142,7 @@ func TestServiceOne(t *testing.T) {
 		require.NoError(t, err)
 
 		host, err := s.One(t.Context(), QueryOptions{})
-		require.EqualError(t, err, ErrNoServiceFound.Error())
+		require.ErrorContains(t, err, ErrNoServiceFound.Error())
 		assert.Nil(t, host)
 	})
 
@@ -189,7 +189,7 @@ func TestServiceOne(t *testing.T) {
 		require.NoError(t, err)
 
 		host, err := s.One(t.Context(), QueryOptions{Shard: testShard2ID})
-		require.EqualError(t, err, ErrNoHostFoundOnShard.Error())
+		require.ErrorContains(t, err, ErrNoHostFoundOnShard.Error())
 		assert.Nil(t, host)
 	})
 }
@@ -233,7 +233,7 @@ func TestServiceURL(t *testing.T) {
 			require.NoError(t, err)
 
 			url, err := s.URL(t.Context(), "htjp", "/path", QueryOptions{})
-			require.EqualError(t, err, "unknown scheme")
+			require.ErrorIs(t, err, ErrUnknownScheme)
 			assert.Empty(t, url)
 		})
 
@@ -269,7 +269,7 @@ func TestServiceURL(t *testing.T) {
 			require.NoError(t, err)
 
 			url, err := s.URL(t.Context(), "http", "/path", QueryOptions{Shard: testShard2ID})
-			require.EqualError(t, err, ErrNoHostFoundOnShard.Error())
+			require.ErrorContains(t, err, ErrNoHostFoundOnShard.Error())
 			assert.Empty(t, url)
 		})
 	})

--- a/service/subscribe.go
+++ b/service/subscribe.go
@@ -2,7 +2,7 @@ package service
 
 import (
 	"context"
-	"errors"
+	stderrors "errors"
 	"path"
 
 	etcdv2 "go.etcd.io/etcd/client/v2"
@@ -96,17 +96,17 @@ func SubscribeNew(ctx context.Context, service string) (<-chan *Host, <-chan *et
 // the errs channel, and supports wrapped errors without panicking on unrelated
 // error types.
 func subscriptionError(err error) *etcdv2.Error {
-	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+	if err == nil || stderrors.Is(err, context.Canceled) || stderrors.Is(err, context.DeadlineExceeded) {
 		return nil
 	}
 
 	var etcdErr *etcdv2.Error
-	if errors.As(err, &etcdErr) {
+	if stderrors.As(err, &etcdErr) {
 		return etcdErr
 	}
 
 	var etcdErrValue etcdv2.Error
-	if errors.As(err, &etcdErrValue) {
+	if stderrors.As(err, &etcdErrValue) {
 		// Some call paths return etcd.Error by value; copy it to preserve the
 		// Subscribe* channel type without requiring callers to special-case it.
 		return &etcdErrValue


### PR DESCRIPTION
Fix #157 #84

Also:
- Pass context everywhere (required to use `github.com/Scalingo/go-utils/errors/v3` package)
- Set-up gomock properly with `mocks.json`/`mocks_sig.json` files
- Update README.md
- Fix linting issues that were already present
- Handle host registration errors consistently
- Use `github.com/Scalingo/go-utils/logger` instead of standard logger
- Some fixes was also done related to addition of context

/!\ A `v8` release will be done after since there is one breaking change (addition of context to all functions/methods)