### PR TITLE
feat(lib): Implement context everywhere where missing in the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * feat: Implement context everywhere where missing in the library
 
 Breaking Changes:
+* Public functions and methods that previously had no `context.Context` parameter now require one
 * `Service.All/First/One/URL` signatures now require `QueryOptions`
 * `Service.All/First/One/URL` now return an error and `nil` hosts when no host was found in etcd, instead of returning an empty host
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * feat(service): Add optional shard field when registering hosts
 * feat(service): Add `GetForShard` to query hosts for a specific shard
 * feat(service): Add `QueryOptions` to `Service.All/First/One/URL` for shard filtering
+* feat: Implement context everywhere where missing in the library
 
 Breaking Changes:
 * `Service.All/First/One/URL` signatures now require `QueryOptions`

--- a/README.md
+++ b/README.md
@@ -131,18 +131,32 @@ notice it and communicating with it, it is necessary to watch these
 notifications.
 
 ```go
-newHosts := service.SubscribeNew("name_of_service")
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+
+newHosts, errs := service.SubscribeNew(ctx, "name_of_service")
 for host := range newHosts {
   fmt.Println(host.Name, "has registered")
+}
+
+if err := <-errs; err != nil {
+  fmt.Println("watch failed:", err)
 }
 ```
 
 ### Watch Down Services
 
 ```go
-deadHosts := service.SubscribeDown("name_of_service")
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+
+deadHosts, errs := service.SubscribeDown(ctx, "name_of_service")
 for hostname := range deadHosts {
   fmt.Println(hostname, "is dead, RIP")
+}
+
+if err := <-errs; err != nil {
+  fmt.Println("watch failed:", err)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,28 +100,35 @@ Shard information is stored per host under `/services/<name>/<uuid>`. It is inte
 Use `Get` to query all hosts for a service:
 
 ```go
-hosts, err := service.Get("my-service").All()
-url, err := service.Get("my-service").URL("http", "/health")
+ctx := context.Background()
+
+hosts, err := service.Get(ctx, "my-service").All(ctx)
+url, err := service.Get(ctx, "my-service").URL(ctx, "http", "/health")
 ```
 
 Use `GetForShard` to restrict host lookups to a specific shard:
 
 ```go
-hosts, err := service.GetForShard("my-service", "shard-0").All()
-url, err := service.GetForShard("my-service", "shard-0").URL("http", "/health")
+ctx := context.Background()
+
+hosts, err := service.GetForShard(ctx, "my-service", "shard-0").All(ctx)
+url, err := service.GetForShard(ctx, "my-service", "shard-0").URL(ctx, "http", "/health")
 ```
 
-`Service.All`, `Service.First`, `Service.One`, and `Service.URL` now take a `service.QueryOptions`
-argument. Pass `service.QueryOptions{}` when no filtering is needed.
+`service.Get`, `service.GetForShard`, `Service.All`, `Service.First`, `Service.One`, and `Service.URL`
+now take a `context.Context`. `Service.All`, `Service.First`, `Service.One`, and `Service.URL` also take a
+`service.QueryOptions` argument. Pass `service.QueryOptions{}` when no filtering is needed.
 
 ```go
-s, err := service.Get("my-service").Service()
+ctx := context.Background()
+
+s, err := service.Get(ctx, "my-service").Service(ctx)
 if err != nil {
   return err
 }
 
-host, err := s.First(service.QueryOptions{Shard: "shard-0"})
-url, err := s.URL("http", "/health", service.QueryOptions{})
+host, err := s.First(ctx, service.QueryOptions{Shard: "shard-0"})
+url, err := s.URL(ctx, "http", "/health", service.QueryOptions{})
 ```
 
 ### Subscribe to New Service

--- a/mocks_sig.json
+++ b/mocks_sig.json
@@ -1,5 +1,5 @@
 {
-  "service.HostResponse": "0b 97 29 29 33 33 82 31 75 38 8d 51 50 d2 25 b9 4f 34 85 64",
-  "service.RegistrationWrapper": "80 6d 3c 7b 36 00 8f 76 6f 80 a5 22 cc f1 02 fc 8b ce 16 43",
-  "service.ServiceResponse": "dc dc d7 93 bf 94 8d 8b 62 bc 5d 84 7e cc 7d 04 af d0 00 e4"
+  "service.HostResponse": "76 07 c1 e1 da 6d e7 af 65 fd 22 44 b0 2a ea 05 21 73 d8 7c",
+  "service.RegistrationWrapper": "76 c4 14 00 1f e2 bc 58 34 4a 64 26 c5 aa f1 25 b2 e0 6a ed",
+  "service.ServiceResponse": "5a ae 89 36 c7 e3 82 bf cf 0b a2 c5 67 c4 98 3f 19 42 19 82"
 }

--- a/service/get.go
+++ b/service/get.go
@@ -11,8 +11,8 @@ import (
 //
 // This interface provides a standard API used for method chaining like:
 //
-//	url, err := Get("my-service").First().URL("http", "/")
-//	url, err := GetForShard("my-service", "shard-0").First().URL("http", "/")
+//	url, err := Get(ctx, "my-service").First(ctx).URL(ctx, "http", "/")
+//	url, err := GetForShard(ctx, "my-service", "shard-0").First(ctx).URL(ctx, "http", "/")
 //
 // To provide such API, go errors need to be stored and sent at the last moment.
 // To do so, each "final" method (like URL or All) will check if the Response is errored,
@@ -21,22 +21,22 @@ type ServiceResponse interface {
 	// Err is the method used to check if the Response is errored.
 	Err() error
 	// Service returns the Service struct representing the requested service
-	Service() (*Service, error)
+	Service(ctx context.Context) (*Service, error)
 	// One return a host of the service chosen randomly
-	One() HostResponse
+	One(ctx context.Context) HostResponse
 	// First return the first host of the service
-	First() HostResponse
+	First(ctx context.Context) HostResponse
 	// All returns all the hosts registered for this service
-	All() (Hosts, error)
+	All(ctx context.Context) (Hosts, error)
 	// URL returns a valid url for this service
-	URL(scheme, path string) (string, error)
+	URL(ctx context.Context, scheme, path string) (string, error)
 }
 
 // Get a service by its name. This method does not directly return the Service, but a ServiceResponse.
 //
 // This permits method chaining like:
 //
-//	url, err := Get("my-service").First().URL("http", "/")
+//	url, err := Get(ctx, "my-service").First(ctx).URL(ctx, "http", "/")
 //
 // If there was an error during the acquisition of the service, this error will be stored in the
 // ServiceResponse. Final methods will check for this error before doing actual logic.
@@ -44,8 +44,8 @@ type ServiceResponse interface {
 // If the service is not found, we won't render an error but will return a service with minimal
 // information. This is done to provide maximal backward compatibility since older versions do
 // not register themselves to the "/services_infos" directory.
-func Get(service string) ServiceResponse {
-	res, err := KAPI().Get(context.Background(), "/services_infos/"+service, nil)
+func Get(ctx context.Context, service string) ServiceResponse {
+	res, err := KAPI().Get(ctx, "/services_infos/"+service, nil)
 
 	if err != nil {
 		if etcdv2.IsKeyNotFound(err) {
@@ -62,7 +62,7 @@ func Get(service string) ServiceResponse {
 		}
 	}
 
-	s, err := buildServiceFromNode(res.Node)
+	s, err := buildServiceFromNode(ctx, res.Node)
 	if err != nil {
 		return &GetServiceResponse{
 			err:     err,
@@ -77,8 +77,8 @@ func Get(service string) ServiceResponse {
 }
 
 // GetForShard is similar to Get, but all host-based operations are filtered on the provided shard.
-func GetForShard(serviceName, shard string) ServiceResponse {
-	res := Get(serviceName)
+func GetForShard(ctx context.Context, serviceName, shard string) ServiceResponse {
+	res := Get(ctx, serviceName)
 	getRes, ok := res.(*GetServiceResponse)
 	if !ok {
 		return res
@@ -106,7 +106,7 @@ func (q *GetServiceResponse) Err() error {
 //
 // If the service was not found, no error will be returned,
 // but the service will only contain a Name field.
-func (q *GetServiceResponse) Service() (*Service, error) {
+func (q *GetServiceResponse) Service(ctx context.Context) (*Service, error) {
 	if q.err != nil {
 		return nil, q.err
 	}
@@ -114,13 +114,13 @@ func (q *GetServiceResponse) Service() (*Service, error) {
 }
 
 // All will return a slice of all the hosts registered to the service
-func (q *GetServiceResponse) All() (Hosts, error) {
+func (q *GetServiceResponse) All(ctx context.Context) (Hosts, error) {
 	if q.err != nil {
 		return nil, q.err
 	}
 
 	opts := QueryOptions{Shard: q.shard}
-	hosts, err := q.service.All(opts)
+	hosts, err := q.service.All(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (q *GetServiceResponse) All() (Hosts, error) {
 // One will return a host chosen randomly in all the hosts of the service.
 //
 // If the ServiceResponse is errored, the errors will be passed to the HostResponse.
-func (q *GetServiceResponse) One() HostResponse {
+func (q *GetServiceResponse) One(ctx context.Context) HostResponse {
 	if q.err != nil {
 		return &GetHostResponse{
 			err:  q.err,
@@ -140,7 +140,7 @@ func (q *GetServiceResponse) One() HostResponse {
 	}
 
 	opts := QueryOptions{Shard: q.shard}
-	host, err := q.service.One(opts)
+	host, err := q.service.One(ctx, opts)
 	if err != nil {
 		return &GetHostResponse{
 			err:  err,
@@ -156,7 +156,7 @@ func (q *GetServiceResponse) One() HostResponse {
 // First will return the first host registered to the service.
 //
 // If the ServiceResponse is errored, the errors will be passed to the HostResponse.
-func (q *GetServiceResponse) First() HostResponse {
+func (q *GetServiceResponse) First(ctx context.Context) HostResponse {
 	if q.err != nil {
 		return &GetHostResponse{
 			err:  q.err,
@@ -165,7 +165,7 @@ func (q *GetServiceResponse) First() HostResponse {
 	}
 
 	opts := QueryOptions{Shard: q.shard}
-	host, err := q.service.First(opts)
+	host, err := q.service.First(ctx, opts)
 	if err != nil {
 		return &GetHostResponse{
 			err:  err,
@@ -180,13 +180,13 @@ func (q *GetServiceResponse) First() HostResponse {
 
 // URL build url for the specified service. If the service is not public,
 // a random host will be chosen and a url will be generated.
-func (q *GetServiceResponse) URL(scheme, path string) (string, error) {
+func (q *GetServiceResponse) URL(ctx context.Context, scheme, path string) (string, error) {
 	if q.err != nil {
 		return "", q.err
 	}
 
 	opts := QueryOptions{Shard: q.shard}
-	url, err := q.service.URL(scheme, path, opts)
+	url, err := q.service.URL(ctx, scheme, path, opts)
 	if err != nil {
 		return "", err
 	}

--- a/service/get_test.go
+++ b/service/get_test.go
@@ -11,13 +11,13 @@ import (
 
 func TestGetNoHost(t *testing.T) {
 	t.Run("Without any service, Get should return ErrNoServiceFound and a nil slice", func(t *testing.T) {
-		hosts, err := Get("test_no_service").All()
+		hosts, err := Get(t.Context(), "test_no_service").All(t.Context())
 		require.EqualError(t, err, ErrNoServiceFound.Error())
 		assert.Nil(t, hosts)
 	})
 
 	t.Run("Without any service, Get().One().Host() should return ErrNoServiceFound", func(t *testing.T) {
-		host, err := Get("test_no_service").One().Host()
+		host, err := Get(t.Context(), "test_no_service").One(t.Context()).Host(t.Context())
 		require.EqualError(t, err, ErrNoServiceFound.Error())
 		assert.Nil(t, host)
 	})
@@ -36,10 +36,10 @@ func TestGet(t *testing.T) {
 		host2.Name = "test_service_get"
 		w1 := Register(ctx1, "test_service_get", host1)
 		w2 := Register(ctx2, "test_service_get", host2)
-		w1.WaitRegistration()
-		w2.WaitRegistration()
+		require.NoError(t, w1.WaitRegistration(t.Context()))
+		require.NoError(t, w2.WaitRegistration(t.Context()))
 
-		hosts, err := Get("test_service_get").All()
+		hosts, err := Get(t.Context(), "test_service_get").All(t.Context())
 		require.NoError(t, err)
 		assert.Len(t, hosts, 2)
 
@@ -71,31 +71,31 @@ func TestGetServiceResponse(t *testing.T) {
 		})
 
 		t.Run("Service should return an error", func(t *testing.T) {
-			service, err := response.Service()
+			service, err := response.Service(t.Context())
 			require.EqualError(t, err, testErrorMsg)
 			assert.Nil(t, service)
 		})
 
 		t.Run("All should return an error", func(t *testing.T) {
-			h, err := response.All()
+			h, err := response.All(t.Context())
 			require.EqualError(t, err, testErrorMsg)
 			assert.Empty(t, h)
 		})
 
-		t.Run("Url should return an error", func(t *testing.T) {
-			url, err := response.URL("http", "/path")
+		t.Run("URL should return an error", func(t *testing.T) {
+			url, err := response.URL(t.Context(), "http", "/path")
 			require.EqualError(t, err, testErrorMsg)
 			assert.Empty(t, url)
 		})
 
 		t.Run("One should return an errored host response", func(t *testing.T) {
-			response := response.One()
+			response := response.One(t.Context())
 			require.NotNil(t, response)
 			require.EqualError(t, response.Err(), testErrorMsg)
 		})
 
 		t.Run("First should return an errored host response", func(t *testing.T) {
-			response := response.First()
+			response := response.First(t.Context())
 			require.NotNil(t, response)
 			require.EqualError(t, response.Err(), testErrorMsg)
 		})
@@ -113,21 +113,31 @@ func TestGetServiceResponse(t *testing.T) {
 		})
 
 		t.Run("Service should respond a valid service", func(t *testing.T) {
-			service, err := response.Service()
+			service, err := response.Service(t.Context())
 			require.NoError(t, err)
 			assert.Equal(t, expectedService, service)
 		})
 
 		t.Run("All should return ErrNoServiceFound when the backing service has no hosts key", func(t *testing.T) {
-			hosts, err := response.All()
+			hosts, err := response.All(t.Context())
 			require.EqualError(t, err, ErrNoServiceFound.Error())
 			assert.Nil(t, hosts)
 		})
 
-		t.Run("Url should return a valid url", func(t *testing.T) {
-			url, err := response.URL("http", "/path")
+		t.Run("URL should return a valid url", func(t *testing.T) {
+			url, err := response.URL(t.Context(), "http", "/path")
 			require.NoError(t, err)
 			assert.Equal(t, "http://user:password@public.dev:80/path", url)
+		})
+
+		t.Run("One should pass the One error", func(t *testing.T) {
+			r := response.One(t.Context())
+			require.EqualError(t, r.Err(), ErrNoServiceFound.Error())
+		})
+
+		t.Run("First should pass the First error", func(t *testing.T) {
+			r := response.First(t.Context())
+			require.EqualError(t, r.Err(), "fetch hosts: "+ErrNoServiceFound.Error())
 		})
 	})
 }
@@ -151,20 +161,20 @@ func TestGetForShard(t *testing.T) {
 
 		w1 := Register(ctx1, "test_service_get_for_shard", hostShard0)
 		w2 := Register(ctx2, "test_service_get_for_shard", hostShard1)
-		w1.WaitRegistration()
-		w2.WaitRegistration()
+		require.NoError(t, w1.WaitRegistration(t.Context()))
+		require.NoError(t, w2.WaitRegistration(t.Context()))
 
-		hosts, err := GetForShard("test_service_get_for_shard", testShardID).All()
+		hosts, err := GetForShard(t.Context(), "test_service_get_for_shard", testShardID).All(t.Context())
 		require.NoError(t, err)
 		require.Len(t, hosts, 1)
 		assert.Equal(t, testShardID, hosts[0].Shard)
 
-		host, err := GetForShard("test_service_get_for_shard", testShard1ID).First().Host()
+		host, err := GetForShard(t.Context(), "test_service_get_for_shard", testShard1ID).First(t.Context()).Host(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, testShard1ID, host.Shard)
 		assert.Equal(t, "host-shard-1.dev", host.Hostname)
 
-		url, err := GetForShard("test_service_get_for_shard", testShard1ID).URL("http", "/path")
+		url, err := GetForShard(t.Context(), "test_service_get_for_shard", testShard1ID).URL(t.Context(), "http", "/path")
 		require.NoError(t, err)
 		assert.Equal(t, "http://user:password@host-shard-1.dev:10000/path", url)
 	})
@@ -173,21 +183,21 @@ func TestGetForShard(t *testing.T) {
 		host := genHost("host-no-match")
 		host.Shard = testShardID
 		w := Register(t.Context(), "test_service_get_for_shard_no_match", host)
-		w.WaitRegistration()
+		require.NoError(t, w.WaitRegistration(t.Context()))
 
-		hosts, err := GetForShard("test_service_get_for_shard_no_match", testShard1ID).All()
+		hosts, err := GetForShard(t.Context(), "test_service_get_for_shard_no_match", testShard1ID).All(t.Context())
 		require.EqualError(t, err, ErrNoHostFoundOnShard.Error())
 		assert.Nil(t, hosts)
 
-		emptyHost, err := GetForShard("test_service_get_for_shard_no_match", "shard-1").First().Host()
+		emptyHost, err := GetForShard(t.Context(), "test_service_get_for_shard_no_match", testShard1ID).First(t.Context()).Host(t.Context())
 		require.EqualError(t, err, "fetch hosts: "+ErrNoHostFoundOnShard.Error())
 		assert.Nil(t, emptyHost)
 
-		oneHost, err := GetForShard("test_service_get_for_shard_no_match", testShard1ID).One().Host()
+		oneHost, err := GetForShard(t.Context(), "test_service_get_for_shard_no_match", testShard1ID).One(t.Context()).Host(t.Context())
 		require.EqualError(t, err, ErrNoHostFoundOnShard.Error())
 		assert.Nil(t, oneHost)
 
-		url, err := GetForShard("test_service_get_for_shard_no_match", testShard1ID).URL("http", "/path")
+		url, err := GetForShard(t.Context(), "test_service_get_for_shard_no_match", testShard1ID).URL(t.Context(), "http", "/path")
 		require.EqualError(t, err, ErrNoHostFoundOnShard.Error())
 		assert.Empty(t, url)
 	})

--- a/service/host.go
+++ b/service/host.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -65,7 +66,7 @@ type Host struct {
 }
 
 // URL will return a valid url to contact this service on the specific protocol provided by the scheme parameter
-func (h *Host) URL(scheme, path string) (string, error) {
+func (h *Host) URL(ctx context.Context, scheme, path string) (string, error) {
 	var (
 		url  string
 		port string
@@ -85,27 +86,22 @@ func (h *Host) URL(scheme, path string) (string, error) {
 	}
 
 	if h.User != "" {
-		url = fmt.Sprintf("%s://%s:%s@%s:%s%s",
-			scheme, h.User, h.Password, h.Hostname, port, path,
-		)
+		url = fmt.Sprintf("%s://%s:%s@%s:%s%s", scheme, h.User, h.Password, h.Hostname, port, path)
 	} else {
-		url = fmt.Sprintf("%s://%s:%s%s",
-			scheme, h.Hostname, port, path,
-		)
+		url = fmt.Sprintf("%s://%s:%s%s", scheme, h.Hostname, port, path)
 	}
 	return url, nil
 }
 
 // PrivateURL will provide a valid url to contact this service on the Private network
 // this method will fall back to the URL method if the host does not provide any PrivateURL
-func (h *Host) PrivateURL(scheme, path string) (string, error) {
+func (h *Host) PrivateURL(ctx context.Context, scheme, path string) (string, error) {
 	if h.PrivateHostname == "" {
-		url, err := h.URL(scheme, path)
+		url, err := h.URL(ctx, scheme, path)
 		if err != nil {
 			return "", errgo.Mask(err)
-		} else {
-			return url, nil
 		}
+		return url, nil
 	}
 
 	var (
@@ -127,12 +123,9 @@ func (h *Host) PrivateURL(scheme, path string) (string, error) {
 	}
 
 	if h.User != "" {
-		url = fmt.Sprintf("%s://%s:%s@%s:%s%s",
-			scheme, h.User, h.Password, h.PrivateHostname, port, path,
-		)
+		url = fmt.Sprintf("%s://%s:%s@%s:%s%s", scheme, h.User, h.Password, h.PrivateHostname, port, path)
 	} else {
-		url = fmt.Sprintf("%s://%s:%s%s",
-			scheme, h.PrivateHostname, port, path)
+		url = fmt.Sprintf("%s://%s:%s%s", scheme, h.PrivateHostname, port, path)
 	}
 	return url, nil
 }
@@ -150,16 +143,16 @@ func (h *Host) findSchemeAndPort(ports Ports) (string, string, error) {
 // HostResponse is the interface used to provide a single host response.
 // This interface provides a standard API used for method chaining like:
 //
-//	url, err := Get("my-service").First().URL("http", "/")
+//	url, err := Get(ctx, "my-service").First(ctx).URL(ctx, "http", "/")
 //
 // To provide such API errors need to be stored and sent at the last moment.
 // To do so, each "final" method (like URL or Host) will check if the Response is errored before
 // continuing to their own logic.
 type HostResponse interface {
 	Err() error
-	Host() (*Host, error)
-	URL(scheme, path string) (string, error)
-	PrivateURL(scheme, path string) (string, error)
+	Host(ctx context.Context) (*Host, error)
+	URL(ctx context.Context, scheme, path string) (string, error)
+	PrivateURL(ctx context.Context, scheme, path string) (string, error)
 }
 
 // GetHostResponse is the HostResponse Implementation of the HostResponse interface used by the the Service methods.
@@ -169,13 +162,13 @@ type GetHostResponse struct {
 	host *Host
 }
 
-// Err will return an error if an error happened on any previous steps.
+// Err returns an error if an error happened on any previous steps.
 func (q *GetHostResponse) Err() error {
 	return q.err
 }
 
 // Host will return the host represented by this error.
-func (q *GetHostResponse) Host() (*Host, error) {
+func (q *GetHostResponse) Host(ctx context.Context) (*Host, error) {
 	if q.err != nil {
 		return nil, q.err
 	}
@@ -184,11 +177,11 @@ func (q *GetHostResponse) Host() (*Host, error) {
 }
 
 // URL will return the public URL of this host
-func (q *GetHostResponse) URL(scheme, path string) (string, error) {
+func (q *GetHostResponse) URL(ctx context.Context, scheme, path string) (string, error) {
 	if q.err != nil {
 		return "", q.err
 	}
-	url, err := q.host.URL(scheme, path)
+	url, err := q.host.URL(ctx, scheme, path)
 	if err != nil {
 		return "", err
 	}
@@ -196,11 +189,11 @@ func (q *GetHostResponse) URL(scheme, path string) (string, error) {
 }
 
 // PrivateURL will return the private URL of this host
-func (q *GetHostResponse) PrivateURL(scheme, path string) (string, error) {
+func (q *GetHostResponse) PrivateURL(ctx context.Context, scheme, path string) (string, error) {
 	if q.err != nil {
 		return "", q.err
 	}
-	url, err := q.host.PrivateURL(scheme, path)
+	url, err := q.host.PrivateURL(ctx, scheme, path)
 	if err != nil {
 		return "", err
 	}

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -14,21 +14,21 @@ func TestHostUrl(t *testing.T) {
 		host.User = ""
 		host.Password = ""
 
-		url, err := host.URL("http", "/path")
+		url, err := host.URL(t.Context(), "http", "/path")
 		require.NoError(t, err)
 		assert.Equal(t, "http://public.dev:10000/path", url)
 	})
 
 	t.Run("With a host with a password", func(t *testing.T) {
 		host := genHost("test")
-		url, err := host.URL("http", "/path")
+		url, err := host.URL(t.Context(), "http", "/path")
 		require.NoError(t, err)
 		assert.Equal(t, "http://user:password@public.dev:10000/path", url)
 	})
 
 	t.Run("When the port doesn't exists", func(t *testing.T) {
 		host := genHost("test")
-		url, err := host.URL("htjp", "/path")
+		url, err := host.URL(t.Context(), "htjp", "/path")
 		require.Error(t, err)
 		assert.Equal(t, "unknown scheme", err.Error())
 		assert.Equal(t, 0, len(url))
@@ -36,7 +36,7 @@ func TestHostUrl(t *testing.T) {
 
 	t.Run("When the scheme is not provided", func(t *testing.T) {
 		host := genHost("test")
-		url, err := host.URL("", "/path")
+		url, err := host.URL(t.Context(), "", "/path")
 		require.NoError(t, err)
 		assert.Equal(t, "http://user:password@public.dev:10000/path", url)
 	})
@@ -48,21 +48,21 @@ func TestHostPrivateUrl(t *testing.T) {
 		host.User = ""
 		host.Password = ""
 
-		url, err := host.PrivateURL("http", "/path")
+		url, err := host.PrivateURL(t.Context(), "http", "/path")
 		require.NoError(t, err)
 		assert.Equal(t, "http://test-private.dev:20000/path", url)
 	})
 
 	t.Run("With a host with a password", func(t *testing.T) {
 		host := genHost("test")
-		url, err := host.PrivateURL("http", "/path")
+		url, err := host.PrivateURL(t.Context(), "http", "/path")
 		require.NoError(t, err)
 		assert.Equal(t, "http://user:password@test-private.dev:20000/path", url)
 	})
 
 	t.Run("When the port doesn't exists", func(t *testing.T) {
 		host := genHost("test")
-		url, err := host.PrivateURL("htjp", "/path")
+		url, err := host.PrivateURL(t.Context(), "htjp", "/path")
 		require.Error(t, err)
 		assert.Equal(t, "unknown scheme", err.Error())
 		assert.Equal(t, 0, len(url))
@@ -70,7 +70,7 @@ func TestHostPrivateUrl(t *testing.T) {
 
 	t.Run("When the scheme is not provided", func(t *testing.T) {
 		host := genHost("test")
-		url, err := host.PrivateURL("", "/path")
+		url, err := host.PrivateURL(t.Context(), "", "/path")
 		require.NoError(t, err)
 		assert.Equal(t, "http://user:password@test-private.dev:20000/path", url)
 	})
@@ -78,7 +78,7 @@ func TestHostPrivateUrl(t *testing.T) {
 	t.Run("When the host does not support private urls, it should fall back to URL", func(t *testing.T) {
 		host := genHost("test")
 		host.PrivateHostname = ""
-		url, err := host.PrivateURL("http", "/path")
+		url, err := host.PrivateURL(t.Context(), "http", "/path")
 		require.NoError(t, err)
 		assert.Equal(t, "http://user:password@public.dev:10000/path", url)
 	})
@@ -112,23 +112,23 @@ func TestGetHostResponse(t *testing.T) {
 		})
 
 		t.Run("The Host method should return an error", func(t *testing.T) {
-			host, err := response.Host()
+			host, err := response.Host(t.Context())
 			require.Error(t, err)
-			assert.Equal(t, "TestError", response.Err().Error())
+			assert.Equal(t, "TestError", err.Error())
 			assert.Nil(t, host)
 		})
 
 		t.Run("The URL method should return an error", func(t *testing.T) {
-			url, err := response.URL("http", "/path")
+			url, err := response.URL(t.Context(), "http", "/path")
 			require.Error(t, err)
-			assert.Equal(t, "TestError", response.Err().Error())
+			assert.Equal(t, "TestError", err.Error())
 			assert.Equal(t, "", url)
 		})
 
 		t.Run("The PrivateURL should return an error", func(t *testing.T) {
-			url, err := response.PrivateURL("http", "/path")
+			url, err := response.PrivateURL(t.Context(), "http", "/path")
 			require.Error(t, err)
-			assert.Equal(t, "TestError", response.Err().Error())
+			assert.Equal(t, "TestError", err.Error())
 			assert.Equal(t, "", url)
 		})
 	})
@@ -145,19 +145,19 @@ func TestGetHostResponse(t *testing.T) {
 		})
 
 		t.Run("The Host method should return a valid host", func(t *testing.T) {
-			h, err := response.Host()
+			h, err := response.Host(t.Context())
 			require.NoError(t, err)
 			assert.Equal(t, &host, h)
 		})
 
 		t.Run("The URL method should return a valid url", func(t *testing.T) {
-			url, err := response.URL("http", "/path")
+			url, err := response.URL(t.Context(), "http", "/path")
 			require.NoError(t, err)
 			assert.Equal(t, "http://user:password@public.dev:10000/path", url)
 		})
 
 		t.Run("The Private URL should return a valid url", func(t *testing.T) {
-			url, err := response.PrivateURL("http", "/path")
+			url, err := response.PrivateURL(t.Context(), "http", "/path")
 			require.NoError(t, err)
 			assert.Equal(t, "http://user:password@test-service-private.dev:20000/path", url)
 		})

--- a/service/parser.go
+++ b/service/parser.go
@@ -1,16 +1,17 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
 
 	etcdv2 "go.etcd.io/etcd/client/v2"
 	"gopkg.in/errgo.v1"
 )
 
-func buildHostsFromNodes(nodes etcdv2.Nodes) (Hosts, error) {
+func buildHostsFromNodes(ctx context.Context, nodes etcdv2.Nodes) (Hosts, error) {
 	hosts := make(Hosts, len(nodes))
 	for i, node := range nodes {
-		host, err := buildHostFromNode(node)
+		host, err := buildHostFromNode(ctx, node)
 		if err != nil {
 			return nil, errgo.Mask(err)
 		}
@@ -19,7 +20,7 @@ func buildHostsFromNodes(nodes etcdv2.Nodes) (Hosts, error) {
 	return hosts, nil
 }
 
-func buildHostFromNode(node *etcdv2.Node) (*Host, error) {
+func buildHostFromNode(_ context.Context, node *etcdv2.Node) (*Host, error) {
 	host := &Host{}
 	err := json.Unmarshal([]byte(node.Value), host)
 	if err != nil {
@@ -28,7 +29,7 @@ func buildHostFromNode(node *etcdv2.Node) (*Host, error) {
 	return host, nil
 }
 
-func buildServiceFromNode(node *etcdv2.Node) (*Service, error) {
+func buildServiceFromNode(_ context.Context, node *etcdv2.Node) (*Service, error) {
 	service := &Service{}
 	err := json.Unmarshal([]byte(node.Value), service)
 	if err != nil {

--- a/service/parser_test.go
+++ b/service/parser_test.go
@@ -47,7 +47,7 @@ var (
 
 func TestBuildHostsFromNodes(t *testing.T) {
 	t.Run("Given a sample response with 2 nodes, we got 2 hosts", func(t *testing.T) {
-		hosts, err := buildHostsFromNodes(sampleNodes)
+		hosts, err := buildHostsFromNodes(t.Context(), sampleNodes)
 		require.NoError(t, err)
 		assert.Len(t, hosts, 2)
 		assert.Equal(t, sampleResult, *hosts[0])
@@ -57,7 +57,7 @@ func TestBuildHostsFromNodes(t *testing.T) {
 
 func TestBuildHostFromNode(t *testing.T) {
 	t.Run("Given a sample response, we got a filled Host", func(t *testing.T) {
-		host, err := buildHostFromNode(sampleNode)
+		host, err := buildHostFromNode(t.Context(), sampleNode)
 		require.NoError(t, err)
 		assert.Equal(t, sampleResult, *host)
 	})
@@ -65,7 +65,7 @@ func TestBuildHostFromNode(t *testing.T) {
 
 func TestBuildServiceFromNode(t *testing.T) {
 	t.Run("Given a sample response, we got a filled Infos", func(t *testing.T) {
-		infos, err := buildServiceFromNode(sampleInfoNode)
+		infos, err := buildServiceFromNode(t.Context(), sampleInfoNode)
 		require.NoError(t, err)
 		assert.True(t, infos.Critical)
 	})

--- a/service/register.go
+++ b/service/register.go
@@ -23,7 +23,7 @@ const (
 //
 // This service will launch two go routines. The first one will maintain the
 // registration every 5 seconds, and the second one will check if the service
-// credentials don't change and notify otherwise
+// credentials don't change and notify otherwise.
 func Register(ctx context.Context, service string, host Host) *Registration {
 	if !host.Public && len(host.PrivateHostname) == 0 {
 		host.PrivateHostname = host.Hostname
@@ -39,8 +39,8 @@ func Register(ctx context.Context, service string, host Host) *Registration {
 	}
 
 	uuidV4, _ := uuid.NewV4()
-	hostUuid := fmt.Sprintf("%s-%s", uuidV4.String(), host.PrivateHostname)
-	host.UUID = hostUuid
+	hostUUID := fmt.Sprintf("%s-%s", uuidV4.String(), host.PrivateHostname)
+	host.UUID = hostUUID
 
 	serviceInfos := &Service{
 		Name:     service,
@@ -58,27 +58,31 @@ func Register(ctx context.Context, service string, host Host) *Registration {
 	publicCredentialsChan := make(chan Credentials, 1)  // Communication between register and the client
 	privateCredentialsChan := make(chan Credentials, 1) // Communication between watcher and register
 
-	hostKey := fmt.Sprintf("/services/%s/%s", service, hostUuid)
-	hostJson, _ := json.Marshal(&host)
-	hostValue := string(hostJson)
+	hostKey := fmt.Sprintf("/services/%s/%s", service, hostUUID)
+	hostJSON, _ := json.Marshal(&host)
+	hostValue := string(hostJSON)
 
 	serviceKey := fmt.Sprintf("/services_infos/%s", service)
-	serviceJson, _ := json.Marshal(serviceInfos)
-	serviceValue := string(serviceJson)
+	serviceJSON, _ := json.Marshal(serviceInfos)
+	serviceValue := string(serviceJSON)
 
 	go func() {
 		ticker := time.NewTicker((HEARTBEAT_DURATION - 1) * time.Second)
+		defer ticker.Stop()
 
 		// id is the current modification index of the service key.
 		// this is used for the watcher.
-		id, err := serviceRegistration(serviceKey, serviceValue)
+		id, err := serviceRegistration(ctx, serviceKey, serviceValue)
 		for err != nil {
-			id, err = serviceRegistration(serviceKey, serviceValue)
+			if ctx.Err() != nil {
+				return
+			}
+			id, err = serviceRegistration(ctx, serviceKey, serviceValue)
 		}
 
-		err = hostRegistration(hostKey, hostValue)
-		for err != nil {
-			err = hostRegistration(hostKey, hostValue)
+		err = ensureHostRegistration(ctx, service, hostKey, hostValue, false)
+		if err != nil {
+			return
 		}
 
 		publicCredentialsChan <- Credentials{
@@ -93,11 +97,10 @@ func Register(ctx context.Context, service string, host Host) *Registration {
 		for {
 			select {
 			case <-ctx.Done():
-				_, err := KAPI().Delete(context.Background(), hostKey, &etcdv2.DeleteOptions{Recursive: false})
+				_, err := KAPI().Delete(ctx, hostKey, &etcdv2.DeleteOptions{Recursive: false})
 				if err != nil {
-					logger.Println("fail to remove key", hostKey)
+					logger.Println("remove host key", hostKey)
 				}
-				ticker.Stop()
 				return
 			case credentials := <-privateCredentialsChan: // If the credentials have been changed,
 				// We update our cache
@@ -107,31 +110,26 @@ func Register(ctx context.Context, service string, host Host) *Registration {
 				serviceInfos.Password = credentials.Password
 
 				// Re-marshal the host
-				hostJson, _ = json.Marshal(&host)
-				hostValue = string(hostJson)
+				hostJSON, _ = json.Marshal(&host)
+				hostValue = string(hostJSON)
 
 				// Sync the host information
-				hostRegistration(hostKey, hostValue)
+				err := ensureHostRegistration(ctx, service, hostKey, hostValue, true)
+				if err != nil {
+					return
+				}
 				// and transmit them to the client
 				publicCredentialsChan <- credentials
 			case <-ticker.C:
-				err := hostRegistration(hostKey, hostValue)
-				// If for any random reason, there is an error,
-				// we retry every second until it's ok.
-				for err != nil {
-					logger.Printf("lost registration of '%v': %v (%v)", service, err, Client().Endpoints())
-					time.Sleep(1 * time.Second)
-
-					err = hostRegistration(hostKey, hostValue)
-					if err == nil {
-						logger.Printf("recover registration of '%v'", service)
-					}
+				err := ensureHostRegistration(ctx, service, hostKey, hostValue, true)
+				if err != nil {
+					return
 				}
 			}
 		}
 	}()
 
-	return NewRegistration(ctx, hostUuid, publicCredentialsChan)
+	return NewRegistration(ctx, hostUUID, publicCredentialsChan)
 }
 
 func watch(ctx context.Context, serviceKey string, id uint64, credentialsChan chan Credentials) {
@@ -150,7 +148,7 @@ func watch(ctx context.Context, serviceKey string, id uint64, credentialsChan ch
 
 		if err != nil {
 			// We've lost the connexion to etcd. Sleep 1s and retry
-			logger.Printf("lost watcher of '%v': '%v' (%v)", serviceKey, err, Client().Endpoints())
+			logger.Printf("Lost watcher of '%v': '%v' (%v)", serviceKey, err, Client().Endpoints())
 			id = 0
 			time.Sleep(1 * time.Second)
 			continue
@@ -159,7 +157,7 @@ func watch(ctx context.Context, serviceKey string, id uint64, credentialsChan ch
 		err = json.Unmarshal([]byte(resp.Node.Value), &serviceInfos)
 		if err != nil {
 			logger.Printf(
-				"error while getting service key '%v': '%v' (%v)",
+				"Error while getting service key '%v': '%v' (%v)",
 				serviceKey, err, Client().Endpoints(),
 			)
 			time.Sleep(1 * time.Second)
@@ -173,18 +171,37 @@ func watch(ctx context.Context, serviceKey string, id uint64, credentialsChan ch
 	}
 }
 
-func hostRegistration(hostKey, hostJson string) error {
-	_, err := KAPI().Set(context.Background(), hostKey, hostJson, &etcdv2.SetOptions{
-		TTL: HEARTBEAT_DURATION * time.Second,
-	})
+func hostRegistration(ctx context.Context, hostKey, hostJSON string) error {
+	_, err := KAPI().Set(ctx, hostKey, hostJSON, &etcdv2.SetOptions{TTL: HEARTBEAT_DURATION * time.Second})
 	if err != nil {
 		return errgo.Notef(err, "Unable to register host")
 	}
 	return nil
 }
 
-func serviceRegistration(serviceKey, serviceJson string) (uint64, error) {
-	key, err := KAPI().Set(context.Background(), serviceKey, serviceJson, nil)
+func ensureHostRegistration(ctx context.Context, service, hostKey, hostJSON string, logFailures bool) error {
+	err := hostRegistration(ctx, hostKey, hostJSON)
+	for err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		if logFailures {
+			logger.Printf("Lost registration of '%v': %v (%v)", service, err, Client().Endpoints())
+		}
+		time.Sleep(1 * time.Second)
+
+		err = hostRegistration(ctx, hostKey, hostJSON)
+		if err == nil && logFailures {
+			logger.Printf("Recover registration of '%v'", service)
+		}
+	}
+
+	return nil
+}
+
+func serviceRegistration(ctx context.Context, serviceKey, serviceJSON string) (uint64, error) {
+	key, err := KAPI().Set(ctx, serviceKey, serviceJSON, nil)
 	if err != nil {
 		return 0, errgo.Notef(err, "Unable to register service")
 	}

--- a/service/register.go
+++ b/service/register.go
@@ -77,6 +77,7 @@ func Register(ctx context.Context, service string, host Host) *Registration {
 			if ctx.Err() != nil {
 				return
 			}
+
 			id, err = serviceRegistration(ctx, serviceKey, serviceValue)
 		}
 
@@ -179,6 +180,7 @@ func hostRegistration(ctx context.Context, hostKey, hostJSON string) error {
 	return nil
 }
 
+// ensureHostRegistration keeps retrying the host registration until it succeeds or the context is canceled.
 func ensureHostRegistration(ctx context.Context, service, hostKey, hostJSON string, logFailures bool) error {
 	err := hostRegistration(ctx, hostKey, hostJSON)
 	for err != nil {
@@ -189,7 +191,13 @@ func ensureHostRegistration(ctx context.Context, service, hostKey, hostJSON stri
 		if logFailures {
 			logger.Printf("Lost registration of '%v': %v (%v)", service, err, Client().Endpoints())
 		}
-		time.Sleep(1 * time.Second)
+
+		// Wait for either context cancellation or the next retry attempt.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(1 * time.Second):
+		}
 
 		err = hostRegistration(ctx, hostKey, hostJSON)
 		if err == nil && logFailures {

--- a/service/register_test.go
+++ b/service/register_test.go
@@ -20,7 +20,7 @@ func TestRegister(t *testing.T) {
 		t.Run("It should be available with etcd", func(t *testing.T) {
 			host.Name = "test_register"
 			w := Register(t.Context(), "test_register", host)
-			w.WaitRegistration()
+			require.NoError(t, w.WaitRegistration(t.Context()))
 			uuid := w.UUID()
 			res, err := KAPI().Get(t.Context(), "/services/test_register/"+uuid, &etcdv2.GetOptions{})
 			require.NoError(t, err)
@@ -36,7 +36,7 @@ func TestRegister(t *testing.T) {
 
 		t.Run(fmt.Sprintf("And the ttl must be < %d", HEARTBEAT_DURATION), func(t *testing.T) {
 			w := Register(t.Context(), "test2_register", host)
-			w.WaitRegistration()
+			require.NoError(t, w.WaitRegistration(t.Context()))
 			uuid := w.UUID()
 			res, err := KAPI().Get(t.Context(),
 				"/services/test2_register/"+uuid, &etcdv2.GetOptions{},
@@ -61,7 +61,7 @@ func TestRegister(t *testing.T) {
 				Critical: true,
 			}
 			w := Register(t.Context(), "test3_register", host)
-			w.WaitRegistration()
+			require.NoError(t, w.WaitRegistration(t.Context()))
 			res, err := KAPI().Get(t.Context(), "/services_infos/test3_register", &etcdv2.GetOptions{})
 			require.NoError(t, err)
 
@@ -76,7 +76,7 @@ func TestRegister(t *testing.T) {
 			hostWithShard.Shard = "shard-0"
 
 			w := Register(t.Context(), "test5_register", hostWithShard)
-			w.WaitRegistration()
+			require.NoError(t, w.WaitRegistration(t.Context()))
 
 			res, err := KAPI().Get(t.Context(), "/services_infos/test5_register", &etcdv2.GetOptions{})
 			require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestRegister(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, "test5_register", service.Name)
 
-			host, err := Get("test5_register").First().Host()
+			host, err := Get(t.Context(), "test5_register").First(t.Context()).Host(t.Context())
 			require.NoError(t, err)
 			assert.Equal(t, "shard-0", host.Shard)
 		})
@@ -97,7 +97,7 @@ func TestRegister(t *testing.T) {
 			hostWithoutShard.Shard = ""
 
 			w := Register(t.Context(), "test6_register", hostWithoutShard)
-			w.WaitRegistration()
+			require.NoError(t, w.WaitRegistration(t.Context()))
 
 			resService, err := KAPI().Get(t.Context(), "/services_infos/test6_register", &etcdv2.GetOptions{})
 			require.NoError(t, err)
@@ -122,7 +122,7 @@ func TestRegister(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 			host := genHost("test-disappear")
 			w := Register(ctx, "test4_register", host)
-			w.WaitRegistration()
+			require.NoError(t, w.WaitRegistration(t.Context()))
 			hostKey := "/services/test4_register/" + w.UUID()
 			cancel()
 			time.Sleep(100 * time.Millisecond)
@@ -142,8 +142,8 @@ func TestRegister(t *testing.T) {
 			host.Public = false
 			host.PrivatePorts = Ports{}
 			w := Register(t.Context(), "hello_world2", host)
-			w.WaitRegistration()
-			h, err := Get("hello_world2").First().Host()
+			require.NoError(t, w.WaitRegistration(t.Context()))
+			h, err := Get(t.Context(), "hello_world2").First(t.Context()).Host(t.Context())
 			require.NoError(t, err)
 
 			assert.Len(t, h.PrivatePorts, 1)
@@ -163,7 +163,7 @@ func TestWatcher(t *testing.T) {
 		host2.Password = "password2"
 
 		w1 := Register(t.Context(), "test-watcher", host1)
-		w1.WaitRegistration()
+		require.NoError(t, w1.WaitRegistration(t.Context()))
 
 		cred1, err := w1.Credentials()
 		require.NoError(t, err)
@@ -171,7 +171,7 @@ func TestWatcher(t *testing.T) {
 		assert.Equal(t, "password1", cred1.Password)
 
 		w2 := Register(t.Context(), "test-watcher", host2)
-		w2.WaitRegistration()
+		require.NoError(t, w2.WaitRegistration(t.Context()))
 
 		t.Run("it should send the new passwords", func(t *testing.T) {
 			cred2, err := w2.Credentials()

--- a/service/register_test.go
+++ b/service/register_test.go
@@ -125,10 +125,10 @@ func TestRegister(t *testing.T) {
 			require.NoError(t, w.WaitRegistration(t.Context()))
 			hostKey := "/services/test4_register/" + w.UUID()
 			cancel()
-			time.Sleep(100 * time.Millisecond)
-			_, err := KAPI().Get(t.Context(), hostKey, &etcdv2.GetOptions{})
-			require.Error(t, err)
-			assert.True(t, etcdv2.IsKeyNotFound(err))
+			assert.Eventually(t, func() bool {
+				_, err := KAPI().Get(t.Context(), hostKey, &etcdv2.GetOptions{})
+				return etcdv2.IsKeyNotFound(err)
+			}, (HEARTBEAT_DURATION+2)*time.Second, 100*time.Millisecond)
 		})
 
 		t.Run("When the private_hostname is not set, it must take the node hostname", func(t *testing.T) {

--- a/service/registration.go
+++ b/service/registration.go
@@ -42,7 +42,8 @@ func NewRegistration(ctx context.Context, uuid string, cred chan Credentials) *R
 	return r
 }
 
-// WaitRegistration wait for the first registration to happen, meaning that the service is succesfulled registred to the etcd service
+// WaitRegistration wait for the first registration to happen, meaning that the service is successfully registered on the etcd server.
+// It also returns if the caller context is canceled before the first credentials arrive.
 func (w *Registration) WaitRegistration(ctx context.Context) error {
 	if w.Ready() {
 		return nil
@@ -50,6 +51,8 @@ func (w *Registration) WaitRegistration(ctx context.Context) error {
 
 	select {
 	case <-ctx.Done():
+		// This context only controls the current wait call. The background worker
+		// keeps listening for the registration until its own parent context ends.
 		return ctx.Err()
 	case <-w.readyChan:
 		w.mutex.Lock()
@@ -87,12 +90,14 @@ func (w *Registration) worker(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			// Unblock WaitRegistration callers even if the registration never reached etcd.
 			w.signalReady(ctx.Err())
 			return
 		case newCred := <-w.credChan:
 			w.mutex.Lock()
 			w.curCredentials = &newCred
 			if !w.ready {
+				// The first credentials mark the registration as usable. Later updates only refresh the cache.
 				w.ready = true
 			}
 			w.mutex.Unlock()
@@ -103,6 +108,9 @@ func (w *Registration) worker(ctx context.Context) {
 
 func (w *Registration) signalReady(err error) {
 	w.signalReadyOnce.Do(func() {
+		// Registration can become "ready" either because the first credentials arrived
+		// or because the parent context ended first. Close the wait channel only once
+		// so concurrent callers observe a single outcome.
 		w.mutex.Lock()
 		w.waitErr = err
 		w.mutex.Unlock()

--- a/service/registration.go
+++ b/service/registration.go
@@ -6,12 +6,12 @@ import (
 	"sync"
 )
 
-// RegistrationWrapper wreap the uuid and the credential channel to provide a more user friendly API for the Register Method
+// RegistrationWrapper wraps the uuid and the credential channel to provide a more user-friendly API for the Register Method
 type RegistrationWrapper interface {
-	Ready() bool                                // Ready return strue if the service registred yet? This method should no be blocking
-	WaitRegistration(ctx context.Context) error // WaitRegistration wait for the first registration
-	Credentials() (Credentials, error)          // Credentials return the current credentials or an error if the service is not registred yet
-	UUID() string                               // UUID return the host UUID
+	Ready() bool                                // Ready returns true if the service is registered. This method should not be blocking.
+	WaitRegistration(ctx context.Context) error // WaitRegistration waits for the first registration
+	Credentials() (Credentials, error)          // Credentials returns the current credentials or an error if the service is not registered yet
+	UUID() string                               // UUID returns the host UUID
 }
 
 // Registration is the RegistrationWrapper implementation used by the Register method
@@ -62,7 +62,7 @@ func (w *Registration) WaitRegistration(ctx context.Context) error {
 	}
 }
 
-// Ready is a non blocking method that return true if the service is registred to the etcd service false otherwise
+// Ready is a non blocking method that return true if the service is registered to the etcd service false otherwise
 func (w *Registration) Ready() bool {
 	w.mutex.Lock()
 	ready := w.ready
@@ -75,7 +75,7 @@ func (w *Registration) UUID() string {
 	return w.uuid
 }
 
-// Credentials return the service credentials or an error if the service is not registred yet
+// Credentials return the service credentials or an error if the service is not registered yet
 func (w *Registration) Credentials() (Credentials, error) {
 	w.mutex.Lock()
 	cred := w.curCredentials

--- a/service/registration.go
+++ b/service/registration.go
@@ -8,42 +8,55 @@ import (
 
 // RegistrationWrapper wreap the uuid and the credential channel to provide a more user friendly API for the Register Method
 type RegistrationWrapper interface {
-	Ready() bool                       // Ready return strue if the service registred yet? This method should no be blocking
-	WaitRegistration()                 // WaitRegistration wait for the first registration
-	Credentials() (Credentials, error) // Credentials return the current credentials or an error if the service is not registred yet
-	UUID() string                      // UUID return the host UUID
+	Ready() bool                                // Ready return strue if the service registred yet? This method should no be blocking
+	WaitRegistration(ctx context.Context) error // WaitRegistration wait for the first registration
+	Credentials() (Credentials, error)          // Credentials return the current credentials or an error if the service is not registred yet
+	UUID() string                               // UUID return the host UUID
 }
 
 // Registration is the RegistrationWrapper implementation used by the Register method
 type Registration struct {
-	credChan       chan (Credentials)
-	readyChan      chan bool
-	ready          bool
-	uuid           string
-	mutex          sync.Mutex
-	curCredentials *Credentials
+	credChan        chan Credentials
+	readyChan       chan struct{}
+	ready           bool
+	waitErr         error
+	uuid            string
+	mutex           sync.Mutex
+	signalReadyOnce sync.Once
+	curCredentials  *Credentials
 }
 
 // NewRegistration initialize the Registration struct
 func NewRegistration(ctx context.Context, uuid string, cred chan Credentials) *Registration {
 	r := &Registration{
-		credChan:       cred,
-		readyChan:      make(chan bool, 1),
-		ready:          false,
-		uuid:           uuid,
-		mutex:          sync.Mutex{},
-		curCredentials: nil,
+		credChan:        cred,
+		readyChan:       make(chan struct{}),
+		ready:           false,
+		waitErr:         nil,
+		uuid:            uuid,
+		mutex:           sync.Mutex{},
+		signalReadyOnce: sync.Once{},
+		curCredentials:  nil,
 	}
 	go r.worker(ctx)
 	return r
 }
 
 // WaitRegistration wait for the first registration to happen, meaning that the service is succesfulled registred to the etcd service
-func (w *Registration) WaitRegistration() {
+func (w *Registration) WaitRegistration(ctx context.Context) error {
 	if w.Ready() {
-		return
+		return nil
 	}
-	<-w.readyChan
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-w.readyChan:
+		w.mutex.Lock()
+		err := w.waitErr
+		w.mutex.Unlock()
+		return err
+	}
 }
 
 // Ready is a non blocking method that return true if the service is registred to the etcd service false otherwise
@@ -74,15 +87,25 @@ func (w *Registration) worker(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			w.signalReady(ctx.Err())
 			return
 		case newCred := <-w.credChan:
 			w.mutex.Lock()
 			w.curCredentials = &newCred
 			if !w.ready {
-				w.readyChan <- true
+				w.ready = true
 			}
-			w.ready = true
 			w.mutex.Unlock()
+			w.signalReady(nil)
 		}
 	}
+}
+
+func (w *Registration) signalReady(err error) {
+	w.signalReadyOnce.Do(func() {
+		w.mutex.Lock()
+		w.waitErr = err
+		w.mutex.Unlock()
+		close(w.readyChan)
+	})
 }

--- a/service/registration_test.go
+++ b/service/registration_test.go
@@ -39,7 +39,7 @@ func TestWaitRegistration(t *testing.T) {
 		registrationChan := make(chan bool)
 		go func() {
 			for {
-				r.WaitRegistration()
+				_ = r.WaitRegistration(t.Context())
 				registrationChan <- true
 			}
 		}()

--- a/service/service.go
+++ b/service/service.go
@@ -41,8 +41,8 @@ type QueryOptions struct {
 }
 
 // All returns all hosts associated with a service
-func (s *Service) All(queryOpts QueryOptions) (Hosts, error) {
-	res, err := KAPI().Get(context.Background(), "/services/"+s.Name, &etcdv2.GetOptions{
+func (s *Service) All(ctx context.Context, queryOpts QueryOptions) (Hosts, error) {
+	res, err := KAPI().Get(ctx, "/services/"+s.Name, &etcdv2.GetOptions{
 		Recursive: true,
 	})
 
@@ -53,7 +53,7 @@ func (s *Service) All(queryOpts QueryOptions) (Hosts, error) {
 		return nil, errgo.Notef(err, "Unable to fetch services")
 	}
 
-	hosts, err := buildHostsFromNodes(res.Node.Nodes)
+	hosts, err := buildHostsFromNodes(ctx, res.Node.Nodes)
 	if err != nil {
 		return nil, errgo.Mask(err)
 	}
@@ -83,8 +83,8 @@ func (s *Service) All(queryOpts QueryOptions) (Hosts, error) {
 }
 
 // First returns the first host of this service
-func (s *Service) First(queryOpts QueryOptions) (*Host, error) {
-	hosts, err := s.All(queryOpts)
+func (s *Service) First(ctx context.Context, queryOpts QueryOptions) (*Host, error) {
+	hosts, err := s.All(ctx, queryOpts)
 	if err != nil {
 		return nil, errgo.Notef(err, "fetch hosts")
 	}
@@ -93,9 +93,8 @@ func (s *Service) First(queryOpts QueryOptions) (*Host, error) {
 }
 
 // One returns a random host from all the available hosts of this service.
-func (s *Service) One(queryOpts QueryOptions) (*Host, error) {
-	hosts, err := s.All(queryOpts)
-
+func (s *Service) One(ctx context.Context, queryOpts QueryOptions) (*Host, error) {
+	hosts, err := s.All(ctx, queryOpts)
 	if err != nil {
 		return nil, errgo.Mask(err)
 	}
@@ -106,19 +105,19 @@ func (s *Service) One(queryOpts QueryOptions) (*Host, error) {
 // URL returns the public url of this service.
 //
 // If this service do not have a public url, this will return a url to a random host.
-func (s *Service) URL(scheme, path string, queryOpts QueryOptions) (string, error) {
+func (s *Service) URL(ctx context.Context, scheme, path string, queryOpts QueryOptions) (string, error) {
 	// If the service is not public, fallback to a random host.
 	// If a shard is requested, always resolve the URL from a host in that shard.
 	//
 	// The public metadata stored under /services_infos/<name> is shared across
 	// all shards, so it cannot identify the public host for a specific shard.
 	if !s.Public || queryOpts.Shard != "" {
-		host, err := s.One(queryOpts)
+		host, err := s.One(ctx, queryOpts)
 		if err != nil {
 			return "", errgo.Mask(err)
 		}
 
-		url, err := host.URL(scheme, path)
+		url, err := host.URL(ctx, scheme, path)
 		if err != nil {
 			return "", errgo.Mask(err)
 		}
@@ -134,13 +133,9 @@ func (s *Service) URL(scheme, path string, queryOpts QueryOptions) (string, erro
 	}
 
 	if s.User != "" {
-		url = fmt.Sprintf("%s://%s:%s@%s:%s%s",
-			scheme, s.User, s.Password, s.Hostname, port, path,
-		)
+		url = fmt.Sprintf("%s://%s:%s@%s:%s%s", scheme, s.User, s.Password, s.Hostname, port, path)
 	} else {
-		url = fmt.Sprintf("%s://%s:%s%s",
-			scheme, s.Hostname, port, path,
-		)
+		url = fmt.Sprintf("%s://%s:%s%s", scheme, s.Hostname, port, path)
 	}
 	return url, nil
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestServiceAll(t *testing.T) {
 	t.Run("With no services", func(t *testing.T) {
-		s, err := Get("service-test-get-1").Service()
+		s, err := Get(t.Context(), "service-test-get-1").Service(t.Context())
 		require.NoError(t, err)
 
-		hosts, err := s.All(QueryOptions{})
+		hosts, err := s.All(t.Context(), QueryOptions{})
 		require.EqualError(t, err, ErrNoServiceFound.Error())
 		assert.Nil(t, hosts)
 	})
@@ -23,13 +23,13 @@ func TestServiceAll(t *testing.T) {
 		w1 := Register(t.Context(), "test-get-222", host1)
 		w2 := Register(t.Context(), "test-get-222", host2)
 
-		w1.WaitRegistration()
-		w2.WaitRegistration()
+		require.NoError(t, w1.WaitRegistration(t.Context()))
+		require.NoError(t, w2.WaitRegistration(t.Context()))
 
-		s, err := Get("test-get-222").Service()
+		s, err := Get(t.Context(), "test-get-222").Service(t.Context())
 		require.NoError(t, err)
 
-		hosts, err := s.All(QueryOptions{})
+		hosts, err := s.All(t.Context(), QueryOptions{})
 		require.NoError(t, err)
 		assert.Len(t, hosts, 2)
 		if hosts[0].PrivateHostname == "test1-private.dev" {
@@ -44,17 +44,17 @@ func TestServiceAll(t *testing.T) {
 		host1 := genHost("test-service-all-shard-1")
 		host1.Shard = testShard1ID
 		w1 := Register(t.Context(), "test-service-all-shard", host1)
-		w1.WaitRegistration()
+		require.NoError(t, w1.WaitRegistration(t.Context()))
 
 		host2 := genHost("test-service-all-shard-2")
 		host2.Shard = testShard2ID
 		w2 := Register(t.Context(), "test-service-all-shard", host2)
-		w2.WaitRegistration()
+		require.NoError(t, w2.WaitRegistration(t.Context()))
 
-		s, err := Get("test-service-all-shard").Service()
+		s, err := Get(t.Context(), "test-service-all-shard").Service(t.Context())
 		require.NoError(t, err)
 
-		hosts, err := s.All(QueryOptions{Shard: testShard2ID})
+		hosts, err := s.All(t.Context(), QueryOptions{Shard: testShard2ID})
 		require.NoError(t, err)
 		require.Len(t, hosts, 1)
 		assert.Equal(t, testShard2ID, hosts[0].Shard)
@@ -65,12 +65,12 @@ func TestServiceAll(t *testing.T) {
 		host := genHost("test-service-all-shard-no-match")
 		host.Shard = testShard1ID
 		w := Register(t.Context(), "test-service-all-shard-no-match", host)
-		w.WaitRegistration()
+		require.NoError(t, w.WaitRegistration(t.Context()))
 
-		s, err := Get("test-service-all-shard-no-match").Service()
+		s, err := Get(t.Context(), "test-service-all-shard-no-match").Service(t.Context())
 		require.NoError(t, err)
 
-		hosts, err := s.All(QueryOptions{Shard: testShard2ID})
+		hosts, err := s.All(t.Context(), QueryOptions{Shard: testShard2ID})
 		require.EqualError(t, err, ErrNoHostFoundOnShard.Error())
 		assert.Nil(t, hosts)
 	})
@@ -78,10 +78,10 @@ func TestServiceAll(t *testing.T) {
 
 func TestServiceFirst(t *testing.T) {
 	t.Run("Without a service host, it should return ErrNoServiceFound", func(t *testing.T) {
-		s, err := Get("test-service-first-empty").Service()
+		s, err := Get(t.Context(), "test-service-first-empty").Service(t.Context())
 		require.NoError(t, err)
 
-		host, err := s.First(QueryOptions{})
+		host, err := s.First(t.Context(), QueryOptions{})
 		require.EqualError(t, err, "fetch hosts: "+ErrNoServiceFound.Error())
 		assert.Nil(t, host)
 	})
@@ -89,12 +89,12 @@ func TestServiceFirst(t *testing.T) {
 	t.Run("With a service", func(t *testing.T) {
 		host1 := genHost("test1")
 		w := Register(t.Context(), "test-truc", host1)
-		w.WaitRegistration()
+		require.NoError(t, w.WaitRegistration(t.Context()))
 
-		s, err := Get("test-truc").Service()
+		s, err := Get(t.Context(), "test-truc").Service(t.Context())
 		require.NoError(t, err)
 
-		host, err := s.First(QueryOptions{})
+		host, err := s.First(t.Context(), QueryOptions{})
 		require.NoError(t, err)
 		assert.NotNil(t, host)
 		assert.Equal(t, host1.PrivateHostname, host.PrivateHostname)
@@ -104,17 +104,17 @@ func TestServiceFirst(t *testing.T) {
 		host1 := genHost("test-service-first-shard-1")
 		host1.Shard = testShard1ID
 		w1 := Register(t.Context(), "test-service-first-shard", host1)
-		w1.WaitRegistration()
+		require.NoError(t, w1.WaitRegistration(t.Context()))
 
 		host2 := genHost("test-service-first-shard-2")
 		host2.Shard = testShard2ID
 		w2 := Register(t.Context(), "test-service-first-shard", host2)
-		w2.WaitRegistration()
+		require.NoError(t, w2.WaitRegistration(t.Context()))
 
-		s, err := Get("test-service-first-shard").Service()
+		s, err := Get(t.Context(), "test-service-first-shard").Service(t.Context())
 		require.NoError(t, err)
 
-		host, err := s.First(QueryOptions{Shard: testShard2ID})
+		host, err := s.First(t.Context(), QueryOptions{Shard: testShard2ID})
 		require.NoError(t, err)
 		require.NotNil(t, host)
 		assert.Equal(t, testShard2ID, host.Shard)
@@ -125,12 +125,12 @@ func TestServiceFirst(t *testing.T) {
 		host1 := genHost("test-service-first-shard-no-match")
 		host1.Shard = testShard1ID
 		w := Register(t.Context(), "test-service-first-shard-no-match", host1)
-		w.WaitRegistration()
+		require.NoError(t, w.WaitRegistration(t.Context()))
 
-		s, err := Get("test-service-first-shard-no-match").Service()
+		s, err := Get(t.Context(), "test-service-first-shard-no-match").Service(t.Context())
 		require.NoError(t, err)
 
-		host, err := s.First(QueryOptions{Shard: testShard2ID})
+		host, err := s.First(t.Context(), QueryOptions{Shard: testShard2ID})
 		require.EqualError(t, err, "fetch hosts: "+ErrNoHostFoundOnShard.Error())
 		assert.Nil(t, host)
 	})
@@ -138,10 +138,10 @@ func TestServiceFirst(t *testing.T) {
 
 func TestServiceOne(t *testing.T) {
 	t.Run("Without a service host, it should return ErrNoServiceFound", func(t *testing.T) {
-		s, err := Get("test-service-one-empty").Service()
+		s, err := Get(t.Context(), "test-service-one-empty").Service(t.Context())
 		require.NoError(t, err)
 
-		host, err := s.One(QueryOptions{})
+		host, err := s.One(t.Context(), QueryOptions{})
 		require.EqualError(t, err, ErrNoServiceFound.Error())
 		assert.Nil(t, host)
 	})
@@ -149,12 +149,12 @@ func TestServiceOne(t *testing.T) {
 	t.Run("With a service", func(t *testing.T) {
 		host1 := genHost("test1")
 		w := Register(t.Context(), "test-truc", host1)
-		w.WaitRegistration()
+		require.NoError(t, w.WaitRegistration(t.Context()))
 
-		s, err := Get("test-truc").Service()
+		s, err := Get(t.Context(), "test-truc").Service(t.Context())
 		require.NoError(t, err)
 
-		host, err := s.One(QueryOptions{})
+		host, err := s.One(t.Context(), QueryOptions{})
 		require.NoError(t, err)
 		assert.NotNil(t, host)
 		assert.Equal(t, host1.PrivateHostname, host.PrivateHostname)
@@ -164,17 +164,17 @@ func TestServiceOne(t *testing.T) {
 		host1 := genHost("test-shard-1")
 		host1.Shard = testShard1ID
 		w1 := Register(t.Context(), "test-shard-truc", host1)
-		w1.WaitRegistration()
+		require.NoError(t, w1.WaitRegistration(t.Context()))
 
 		host2 := genHost("test-shard-2")
 		host2.Shard = testShard2ID
 		w2 := Register(t.Context(), "test-shard-truc", host2)
-		w2.WaitRegistration()
+		require.NoError(t, w2.WaitRegistration(t.Context()))
 
-		s, err := Get("test-shard-truc").Service()
+		s, err := Get(t.Context(), "test-shard-truc").Service(t.Context())
 		require.NoError(t, err)
 
-		host, err := s.One(QueryOptions{Shard: testShard2ID})
+		host, err := s.One(t.Context(), QueryOptions{Shard: testShard2ID})
 		require.NoError(t, err)
 		assert.Equal(t, testShard2ID, host.Shard)
 	})
@@ -183,30 +183,30 @@ func TestServiceOne(t *testing.T) {
 		host1 := genHost("test-shard-no-match")
 		host1.Shard = testShard1ID
 		w := Register(t.Context(), "test-shard-no-match", host1)
-		w.WaitRegistration()
+		require.NoError(t, w.WaitRegistration(t.Context()))
 
-		s, err := Get("test-shard-no-match").Service()
+		s, err := Get(t.Context(), "test-shard-no-match").Service(t.Context())
 		require.NoError(t, err)
 
-		host, err := s.One(QueryOptions{Shard: testShard2ID})
+		host, err := s.One(t.Context(), QueryOptions{Shard: testShard2ID})
 		require.EqualError(t, err, ErrNoHostFoundOnShard.Error())
 		assert.Nil(t, host)
 	})
 }
 
-func TestServiceUrl(t *testing.T) {
+func TestServiceURL(t *testing.T) {
 	t.Run("With a public service", func(t *testing.T) {
 		t.Run("With a service without any password", func(t *testing.T) {
 			host := genHost("test")
 			host.User = ""
 			host.Password = ""
 			w := Register(t.Context(), "service-url-1", host)
-			w.WaitRegistration()
+			require.NoError(t, w.WaitRegistration(t.Context()))
 
-			s, err := Get("service-url-1").Service()
+			s, err := Get(t.Context(), "service-url-1").Service(t.Context())
 			require.NoError(t, err)
 
-			url, err := s.URL("http", "/path", QueryOptions{})
+			url, err := s.URL(t.Context(), "http", "/path", QueryOptions{})
 			require.NoError(t, err)
 			assert.Equal(t, "http://public.dev:10000/path", url)
 		})
@@ -214,12 +214,12 @@ func TestServiceUrl(t *testing.T) {
 		t.Run("With a host with a password", func(t *testing.T) {
 			host := genHost("test")
 			w := Register(t.Context(), "service-url-3", host)
-			w.WaitRegistration()
+			require.NoError(t, w.WaitRegistration(t.Context()))
 
-			s, err := Get("service-url-3").Service()
+			s, err := Get(t.Context(), "service-url-3").Service(t.Context())
 			require.NoError(t, err)
 
-			url, err := s.URL("http", "/path", QueryOptions{})
+			url, err := s.URL(t.Context(), "http", "/path", QueryOptions{})
 			require.NoError(t, err)
 			assert.Equal(t, "http://user:password@public.dev:10000/path", url)
 		})
@@ -227,12 +227,12 @@ func TestServiceUrl(t *testing.T) {
 		t.Run("When the port does'nt exists", func(t *testing.T) {
 			host := genHost("test")
 			w := Register(t.Context(), "service-url-4", host)
-			w.WaitRegistration()
+			require.NoError(t, w.WaitRegistration(t.Context()))
 
-			s, err := Get("service-url-4").Service()
+			s, err := Get(t.Context(), "service-url-4").Service(t.Context())
 			require.NoError(t, err)
 
-			url, err := s.URL("htjp", "/path", QueryOptions{})
+			url, err := s.URL(t.Context(), "htjp", "/path", QueryOptions{})
 			require.EqualError(t, err, "unknown scheme")
 			assert.Empty(t, url)
 		})
@@ -242,18 +242,18 @@ func TestServiceUrl(t *testing.T) {
 			host1.Shard = testShard1ID
 			host1.Hostname = "service-url-shard-1.dev"
 			w1 := Register(t.Context(), "service-url-shard", host1)
-			w1.WaitRegistration()
+			require.NoError(t, w1.WaitRegistration(t.Context()))
 
 			host2 := genHost("service-url-shard-2")
 			host2.Shard = testShard2ID
 			host2.Hostname = "service-url-shard-2.dev"
 			w2 := Register(t.Context(), "service-url-shard", host2)
-			w2.WaitRegistration()
+			require.NoError(t, w2.WaitRegistration(t.Context()))
 
-			s, err := Get("service-url-shard").Service()
+			s, err := Get(t.Context(), "service-url-shard").Service(t.Context())
 			require.NoError(t, err)
 
-			url, err := s.URL("http", "/path", QueryOptions{Shard: testShard2ID})
+			url, err := s.URL(t.Context(), "http", "/path", QueryOptions{Shard: testShard2ID})
 			require.NoError(t, err)
 			assert.Equal(t, "http://user:password@service-url-shard-2.dev:10000/path", url)
 		})
@@ -263,12 +263,12 @@ func TestServiceUrl(t *testing.T) {
 			host.Shard = testShard1ID
 			host.Hostname = "service-url-shard-no-match.dev"
 			w := Register(t.Context(), "service-url-shard-no-match", host)
-			w.WaitRegistration()
+			require.NoError(t, w.WaitRegistration(t.Context()))
 
-			s, err := Get("service-url-shard-no-match").Service()
+			s, err := Get(t.Context(), "service-url-shard-no-match").Service(t.Context())
 			require.NoError(t, err)
 
-			url, err := s.URL("http", "/path", QueryOptions{Shard: testShard2ID})
+			url, err := s.URL(t.Context(), "http", "/path", QueryOptions{Shard: testShard2ID})
 			require.EqualError(t, err, ErrNoHostFoundOnShard.Error())
 			assert.Empty(t, url)
 		})

--- a/service/servicemock/hostresponse_mock.go
+++ b/service/servicemock/hostresponse_mock.go
@@ -5,6 +5,7 @@
 package servicemock
 
 import (
+	context "context"
 	reflect "reflect"
 
 	service "github.com/Scalingo/etcd-discovery/v7/service"
@@ -50,46 +51,46 @@ func (mr *MockHostResponseMockRecorder) Err() *gomock.Call {
 }
 
 // Host mocks base method.
-func (m *MockHostResponse) Host() (*service.Host, error) {
+func (m *MockHostResponse) Host(ctx context.Context) (*service.Host, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Host")
+	ret := m.ctrl.Call(m, "Host", ctx)
 	ret0, _ := ret[0].(*service.Host)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Host indicates an expected call of Host.
-func (mr *MockHostResponseMockRecorder) Host() *gomock.Call {
+func (mr *MockHostResponseMockRecorder) Host(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Host", reflect.TypeOf((*MockHostResponse)(nil).Host))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Host", reflect.TypeOf((*MockHostResponse)(nil).Host), ctx)
 }
 
 // PrivateURL mocks base method.
-func (m *MockHostResponse) PrivateURL(scheme, path string) (string, error) {
+func (m *MockHostResponse) PrivateURL(ctx context.Context, scheme, path string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrivateURL", scheme, path)
+	ret := m.ctrl.Call(m, "PrivateURL", ctx, scheme, path)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PrivateURL indicates an expected call of PrivateURL.
-func (mr *MockHostResponseMockRecorder) PrivateURL(scheme, path any) *gomock.Call {
+func (mr *MockHostResponseMockRecorder) PrivateURL(ctx, scheme, path any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrivateURL", reflect.TypeOf((*MockHostResponse)(nil).PrivateURL), scheme, path)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrivateURL", reflect.TypeOf((*MockHostResponse)(nil).PrivateURL), ctx, scheme, path)
 }
 
 // URL mocks base method.
-func (m *MockHostResponse) URL(scheme, path string) (string, error) {
+func (m *MockHostResponse) URL(ctx context.Context, scheme, path string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "URL", scheme, path)
+	ret := m.ctrl.Call(m, "URL", ctx, scheme, path)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // URL indicates an expected call of URL.
-func (mr *MockHostResponseMockRecorder) URL(scheme, path any) *gomock.Call {
+func (mr *MockHostResponseMockRecorder) URL(ctx, scheme, path any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URL", reflect.TypeOf((*MockHostResponse)(nil).URL), scheme, path)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URL", reflect.TypeOf((*MockHostResponse)(nil).URL), ctx, scheme, path)
 }

--- a/service/servicemock/registrationwrapper_mock.go
+++ b/service/servicemock/registrationwrapper_mock.go
@@ -5,6 +5,7 @@
 package servicemock
 
 import (
+	context "context"
 	reflect "reflect"
 
 	service "github.com/Scalingo/etcd-discovery/v7/service"
@@ -79,13 +80,15 @@ func (mr *MockRegistrationWrapperMockRecorder) UUID() *gomock.Call {
 }
 
 // WaitRegistration mocks base method.
-func (m *MockRegistrationWrapper) WaitRegistration() {
+func (m *MockRegistrationWrapper) WaitRegistration(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "WaitRegistration")
+	ret := m.ctrl.Call(m, "WaitRegistration", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // WaitRegistration indicates an expected call of WaitRegistration.
-func (mr *MockRegistrationWrapperMockRecorder) WaitRegistration() *gomock.Call {
+func (mr *MockRegistrationWrapperMockRecorder) WaitRegistration(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitRegistration", reflect.TypeOf((*MockRegistrationWrapper)(nil).WaitRegistration))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitRegistration", reflect.TypeOf((*MockRegistrationWrapper)(nil).WaitRegistration), ctx)
 }

--- a/service/servicemock/serviceresponse_mock.go
+++ b/service/servicemock/serviceresponse_mock.go
@@ -5,6 +5,7 @@
 package servicemock
 
 import (
+	context "context"
 	reflect "reflect"
 
 	service "github.com/Scalingo/etcd-discovery/v7/service"
@@ -36,18 +37,18 @@ func (m *MockServiceResponse) EXPECT() *MockServiceResponseMockRecorder {
 }
 
 // All mocks base method.
-func (m *MockServiceResponse) All() (service.Hosts, error) {
+func (m *MockServiceResponse) All(ctx context.Context) (service.Hosts, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "All")
+	ret := m.ctrl.Call(m, "All", ctx)
 	ret0, _ := ret[0].(service.Hosts)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // All indicates an expected call of All.
-func (mr *MockServiceResponseMockRecorder) All() *gomock.Call {
+func (mr *MockServiceResponseMockRecorder) All(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "All", reflect.TypeOf((*MockServiceResponse)(nil).All))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "All", reflect.TypeOf((*MockServiceResponse)(nil).All), ctx)
 }
 
 // Err mocks base method.
@@ -65,59 +66,59 @@ func (mr *MockServiceResponseMockRecorder) Err() *gomock.Call {
 }
 
 // First mocks base method.
-func (m *MockServiceResponse) First() service.HostResponse {
+func (m *MockServiceResponse) First(ctx context.Context) service.HostResponse {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "First")
+	ret := m.ctrl.Call(m, "First", ctx)
 	ret0, _ := ret[0].(service.HostResponse)
 	return ret0
 }
 
 // First indicates an expected call of First.
-func (mr *MockServiceResponseMockRecorder) First() *gomock.Call {
+func (mr *MockServiceResponseMockRecorder) First(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "First", reflect.TypeOf((*MockServiceResponse)(nil).First))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "First", reflect.TypeOf((*MockServiceResponse)(nil).First), ctx)
 }
 
 // One mocks base method.
-func (m *MockServiceResponse) One() service.HostResponse {
+func (m *MockServiceResponse) One(ctx context.Context) service.HostResponse {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "One")
+	ret := m.ctrl.Call(m, "One", ctx)
 	ret0, _ := ret[0].(service.HostResponse)
 	return ret0
 }
 
 // One indicates an expected call of One.
-func (mr *MockServiceResponseMockRecorder) One() *gomock.Call {
+func (mr *MockServiceResponseMockRecorder) One(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "One", reflect.TypeOf((*MockServiceResponse)(nil).One))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "One", reflect.TypeOf((*MockServiceResponse)(nil).One), ctx)
 }
 
 // Service mocks base method.
-func (m *MockServiceResponse) Service() (*service.Service, error) {
+func (m *MockServiceResponse) Service(ctx context.Context) (*service.Service, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Service")
+	ret := m.ctrl.Call(m, "Service", ctx)
 	ret0, _ := ret[0].(*service.Service)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Service indicates an expected call of Service.
-func (mr *MockServiceResponseMockRecorder) Service() *gomock.Call {
+func (mr *MockServiceResponseMockRecorder) Service(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Service", reflect.TypeOf((*MockServiceResponse)(nil).Service))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Service", reflect.TypeOf((*MockServiceResponse)(nil).Service), ctx)
 }
 
 // URL mocks base method.
-func (m *MockServiceResponse) URL(scheme, path string) (string, error) {
+func (m *MockServiceResponse) URL(ctx context.Context, scheme, path string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "URL", scheme, path)
+	ret := m.ctrl.Call(m, "URL", ctx, scheme, path)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // URL indicates an expected call of URL.
-func (mr *MockServiceResponseMockRecorder) URL(scheme, path any) *gomock.Call {
+func (mr *MockServiceResponseMockRecorder) URL(ctx, scheme, path any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URL", reflect.TypeOf((*MockServiceResponse)(nil).URL), scheme, path)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URL", reflect.TypeOf((*MockServiceResponse)(nil).URL), ctx, scheme, path)
 }

--- a/service/subscribe.go
+++ b/service/subscribe.go
@@ -10,12 +10,12 @@ import (
 
 var subscribeWatcher = Subscribe
 
-// Subscribe to every event that happen to a service
+// Subscribe to every event that happen to a service.
 func Subscribe(service string) etcdv2.Watcher {
 	return KAPI().Watcher("/services/"+service, &etcdv2.WatcherOptions{Recursive: true})
 }
 
-// SubscribeDown return a channel that will notice you everytime a host loose his etcd registration.
+// SubscribeDown returns a channel that will notice you every time a host loses his etcd registration.
 // The subscription lifetime is tied to ctx so callers can stop the blocking etcd watch cleanly.
 func SubscribeDown(ctx context.Context, service string) (<-chan string, <-chan *etcdv2.Error) {
 	expirations := make(chan string)
@@ -51,7 +51,7 @@ func SubscribeDown(ctx context.Context, service string) (<-chan string, <-chan *
 	return expirations, errs
 }
 
-// SubscribeNew return a channel that will notice you everytime a new host is registered.
+// SubscribeNew returns a channel that will notice you every time a new host is registered.
 // The subscription lifetime is tied to ctx so callers can stop the blocking etcd watch cleanly.
 func SubscribeNew(ctx context.Context, service string) (<-chan *Host, <-chan *etcdv2.Error) {
 	hosts := make(chan *Host)

--- a/service/subscribe.go
+++ b/service/subscribe.go
@@ -8,6 +8,8 @@ import (
 	etcdv2 "go.etcd.io/etcd/client/v2"
 )
 
+var subscribeWatcher = Subscribe
+
 // Subscribe to every event that happen to a service
 func Subscribe(service string) etcdv2.Watcher {
 	return KAPI().Watcher("/services/"+service, &etcdv2.WatcherOptions{Recursive: true})
@@ -17,8 +19,9 @@ func Subscribe(service string) etcdv2.Watcher {
 // The subscription lifetime is tied to ctx so callers can stop the blocking etcd watch cleanly.
 func SubscribeDown(ctx context.Context, service string) (<-chan string, <-chan *etcdv2.Error) {
 	expirations := make(chan string)
-	errs := make(chan *etcdv2.Error)
-	watcher := Subscribe(service)
+	errs := make(chan *etcdv2.Error, 1)
+	watcher := subscribeWatcher(service)
+
 	go func() {
 		var (
 			res *etcdv2.Response
@@ -48,12 +51,13 @@ func SubscribeDown(ctx context.Context, service string) (<-chan string, <-chan *
 	return expirations, errs
 }
 
-// SubscribeNew return a channel that will notice you everytime a new host is registred.
+// SubscribeNew return a channel that will notice you everytime a new host is registered.
 // The subscription lifetime is tied to ctx so callers can stop the blocking etcd watch cleanly.
 func SubscribeNew(ctx context.Context, service string) (<-chan *Host, <-chan *etcdv2.Error) {
 	hosts := make(chan *Host)
-	errs := make(chan *etcdv2.Error)
-	watcher := Subscribe(service)
+	errs := make(chan *etcdv2.Error, 1)
+	watcher := subscribeWatcher(service)
+
 	go func() {
 		var (
 			res *etcdv2.Response

--- a/service/subscribe.go
+++ b/service/subscribe.go
@@ -13,7 +13,7 @@ func Subscribe(service string) etcdv2.Watcher {
 }
 
 // SubscribeDown return a channel that will notice you everytime a host loose his etcd registration
-func SubscribeDown(service string) (<-chan string, <-chan *etcdv2.Error) {
+func SubscribeDown(ctx context.Context, service string) (<-chan string, <-chan *etcdv2.Error) {
 	expirations := make(chan string)
 	errs := make(chan *etcdv2.Error)
 	watcher := Subscribe(service)
@@ -24,7 +24,7 @@ func SubscribeDown(service string) (<-chan string, <-chan *etcdv2.Error) {
 		)
 
 		for {
-			res, err = watcher.Next(context.Background())
+			res, err = watcher.Next(ctx)
 			if err != nil {
 				break
 			}
@@ -33,7 +33,7 @@ func SubscribeDown(service string) (<-chan string, <-chan *etcdv2.Error) {
 				expirations <- path.Base(res.Node.Key)
 			}
 		}
-		if err != nil {
+		if err != nil && err != context.Canceled && err != context.DeadlineExceeded {
 			errs <- err.(*etcdv2.Error)
 		}
 		close(expirations)
@@ -43,7 +43,7 @@ func SubscribeDown(service string) (<-chan string, <-chan *etcdv2.Error) {
 }
 
 // SubscribeNew return a channel that will notice you everytime a new host is registred.
-func SubscribeNew(service string) (<-chan *Host, <-chan *etcdv2.Error) {
+func SubscribeNew(ctx context.Context, service string) (<-chan *Host, <-chan *etcdv2.Error) {
 	hosts := make(chan *Host)
 	errs := make(chan *etcdv2.Error)
 	watcher := Subscribe(service)
@@ -54,19 +54,19 @@ func SubscribeNew(service string) (<-chan *Host, <-chan *etcdv2.Error) {
 		)
 
 		for {
-			res, err = watcher.Next(context.Background())
+			res, err = watcher.Next(ctx)
 			if err != nil {
 				break
 			}
 
 			if res.Action == "create" || (res.PrevNode == nil && res.Action == "set") {
-				host, err := buildHostFromNode(res.Node)
+				host, err := buildHostFromNode(ctx, res.Node)
 				if err == nil {
 					hosts <- host
 				}
 			}
 		}
-		if err != nil {
+		if err != nil && err != context.Canceled && err != context.DeadlineExceeded {
 			errs <- err.(*etcdv2.Error)
 		}
 		close(hosts)

--- a/service/subscribe.go
+++ b/service/subscribe.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"path"
 
 	etcdv2 "go.etcd.io/etcd/client/v2"
@@ -12,7 +13,8 @@ func Subscribe(service string) etcdv2.Watcher {
 	return KAPI().Watcher("/services/"+service, &etcdv2.WatcherOptions{Recursive: true})
 }
 
-// SubscribeDown return a channel that will notice you everytime a host loose his etcd registration
+// SubscribeDown return a channel that will notice you everytime a host loose his etcd registration.
+// The subscription lifetime is tied to ctx so callers can stop the blocking etcd watch cleanly.
 func SubscribeDown(ctx context.Context, service string) (<-chan string, <-chan *etcdv2.Error) {
 	expirations := make(chan string)
 	errs := make(chan *etcdv2.Error)
@@ -24,6 +26,7 @@ func SubscribeDown(ctx context.Context, service string) (<-chan string, <-chan *
 		)
 
 		for {
+			// Watch with the caller context so this goroutine exits as soon as the subscription is canceled.
 			res, err = watcher.Next(ctx)
 			if err != nil {
 				break
@@ -33,9 +36,12 @@ func SubscribeDown(ctx context.Context, service string) (<-chan string, <-chan *
 				expirations <- path.Base(res.Node.Key)
 			}
 		}
-		if err != nil && err != context.Canceled && err != context.DeadlineExceeded {
-			errs <- err.(*etcdv2.Error)
+
+		etcdErr := subscriptionError(err)
+		if etcdErr != nil {
+			errs <- etcdErr
 		}
+
 		close(expirations)
 		close(errs)
 	}()
@@ -43,6 +49,7 @@ func SubscribeDown(ctx context.Context, service string) (<-chan string, <-chan *
 }
 
 // SubscribeNew return a channel that will notice you everytime a new host is registred.
+// The subscription lifetime is tied to ctx so callers can stop the blocking etcd watch cleanly.
 func SubscribeNew(ctx context.Context, service string) (<-chan *Host, <-chan *etcdv2.Error) {
 	hosts := make(chan *Host)
 	errs := make(chan *etcdv2.Error)
@@ -54,23 +61,52 @@ func SubscribeNew(ctx context.Context, service string) (<-chan *Host, <-chan *et
 		)
 
 		for {
+			// Watch with the caller context so this goroutine exits as soon as the subscription is canceled.
 			res, err = watcher.Next(ctx)
 			if err != nil {
 				break
 			}
 
 			if res.Action == "create" || (res.PrevNode == nil && res.Action == "set") {
+				// etcd can report the first write for a key as "set" instead of
+				// "create". A missing previous node still means a brand-new host.
 				host, err := buildHostFromNode(ctx, res.Node)
 				if err == nil {
 					hosts <- host
 				}
 			}
 		}
-		if err != nil && err != context.Canceled && err != context.DeadlineExceeded {
-			errs <- err.(*etcdv2.Error)
+
+		etcdErr := subscriptionError(err)
+		if etcdErr != nil {
+			errs <- etcdErr
 		}
+
 		close(hosts)
 		close(errs)
 	}()
 	return hosts, errs
+}
+
+// subscriptionError ignores context cancellation, forwards only etcd errors to
+// the errs channel, and supports wrapped errors without panicking on unrelated
+// error types.
+func subscriptionError(err error) *etcdv2.Error {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return nil
+	}
+
+	var etcdErr *etcdv2.Error
+	if errors.As(err, &etcdErr) {
+		return etcdErr
+	}
+
+	var etcdErrValue etcdv2.Error
+	if errors.As(err, &etcdErrValue) {
+		// Some call paths return etcd.Error by value; copy it to preserve the
+		// Subscribe* channel type without requiring callers to special-case it.
+		return &etcdErrValue
+	}
+
+	return nil
 }

--- a/service/subscribe_test.go
+++ b/service/subscribe_test.go
@@ -58,14 +58,16 @@ func TestSubscribe(t *testing.T) {
 }
 
 func TestSubscribeDown(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	registrationCtx, cancelRegistration := context.WithCancel(t.Context())
+	subscriptionCtx, cancelSubscription := context.WithCancel(t.Context())
+	defer cancelSubscription()
 
 	t.Run("When the service 'test' is watched and a host expired", func(t *testing.T) {
-		w := Register(ctx, "test_expiration", genHost("test-expiration"))
-		hosts, _ := SubscribeDown("test_expiration")
-		w.WaitRegistration()
+		w := Register(registrationCtx, "test_expiration", genHost("test-expiration"))
+		hosts, _ := SubscribeDown(subscriptionCtx, "test_expiration")
+		require.NoError(t, w.WaitRegistration(t.Context()))
 
-		cancel()
+		cancelRegistration()
 		t.Run("The name of the disappeared host should be returned", func(t *testing.T) {
 			select {
 			case host, ok := <-hosts:
@@ -81,7 +83,7 @@ func TestSubscribeNew(t *testing.T) {
 	defer cancel()
 
 	t.Run("When the service 'test' is watched and a host registered", func(t *testing.T) {
-		hosts, _ := SubscribeNew("test_new")
+		hosts, _ := SubscribeNew(t.Context(), "test_new")
 		time.Sleep(200 * time.Millisecond)
 		newHost := genHost("test-new")
 		Register(ctx, "test_new", newHost)

--- a/service/subscribe_test.go
+++ b/service/subscribe_test.go
@@ -15,6 +15,21 @@ type resAndErr struct {
 	error    error
 }
 
+type fakeWatcher struct {
+	results []resAndErr
+	index   int
+}
+
+func (w *fakeWatcher) Next(context.Context) (*etcdv2.Response, error) {
+	if w.index >= len(w.results) {
+		return nil, context.Canceled
+	}
+
+	result := w.results[w.index]
+	w.index++
+	return result.Response, result.error
+}
+
 func TestSubscribe(t *testing.T) {
 	t.Run("When we subscribe a service, we get all the notifications from it", func(t *testing.T) {
 		watcher := Subscribe("test_subs")
@@ -57,6 +72,34 @@ func TestSubscribe(t *testing.T) {
 	})
 }
 
+func TestSubscribeDownClosesDataChannelWhenErrUnread(t *testing.T) {
+	subscribeWatcher = func(string) etcdv2.Watcher {
+		return &fakeWatcher{
+			results: []resAndErr{
+				{error: &etcdv2.Error{Code: 500, Message: "boom"}},
+			},
+		}
+	}
+	t.Cleanup(func() {
+		subscribeWatcher = Subscribe
+	})
+
+	hosts, errs := SubscribeDown(t.Context(), "test_expiration")
+
+	select {
+	case host, ok := <-hosts:
+		assert.False(t, ok)
+		assert.Empty(t, host)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for hosts channel to close")
+	}
+
+	err, ok := <-errs
+	require.True(t, ok)
+	require.Equal(t, 500, err.Code)
+	require.Equal(t, "boom", err.Message)
+}
+
 func TestSubscribeDown(t *testing.T) {
 	registrationCtx, cancelRegistration := context.WithCancel(t.Context())
 	subscriptionCtx, cancelSubscription := context.WithCancel(t.Context())
@@ -76,6 +119,34 @@ func TestSubscribeDown(t *testing.T) {
 			}
 		})
 	})
+}
+
+func TestSubscribeNewClosesDataChannelWhenErrUnread(t *testing.T) {
+	subscribeWatcher = func(string) etcdv2.Watcher {
+		return &fakeWatcher{
+			results: []resAndErr{
+				{error: &etcdv2.Error{Code: 500, Message: "boom"}},
+			},
+		}
+	}
+	t.Cleanup(func() {
+		subscribeWatcher = Subscribe
+	})
+
+	hosts, errs := SubscribeNew(t.Context(), "test_new")
+
+	select {
+	case host, ok := <-hosts:
+		assert.False(t, ok)
+		assert.Nil(t, host)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for hosts channel to close")
+	}
+
+	err, ok := <-errs
+	require.True(t, ok)
+	require.Equal(t, 500, err.Code)
+	require.Equal(t, "boom", err.Message)
 }
 
 func TestSubscribeNew(t *testing.T) {


### PR DESCRIPTION
Fix #84 



> [!NOTE]
> Standard logger will be replaced by `github.com/Scalingo/go-utils/logger` upcoming PR.
> errgo will be replaced by `github.com/Scalingo/go-utils/errors` upcoming PR.