### PR TITLE
fix(service): Avoid an infinite wait on registrations by timing out after some time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * feat: Implement context everywhere where missing in the library
 * refactor: Replace `errgo` by `github.com/Scalingo/go-utils/errors/v3`
 * refactor: Replace std logger by `github.com/Scalingo/go-utils/logger`
+* fix(service): Avoid an infinite wait on registrations by timing out after 5 minutes
 
 Breaking Changes:
 * Public functions and methods that previously had no `context.Context` parameter now require one

--- a/service/register.go
+++ b/service/register.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	// HEARTBEAT_DURATION time in second between two registrations. The host will
-	// be deleted if etcd didn't receive any new registration in those 5 seconds.
-	HEARTBEAT_DURATION = 5
+	// heartbeatTTL is the etcd TTL for a host registration. The registration is
+	// refreshed before this expires, so the host stays available while healthy.
+	heartbeatTTL = 5 * time.Second
+
 	// defaultRegistrationTimeout is used when the caller does not provide a deadline on context.
 	defaultRegistrationTimeout = 5 * time.Minute
 )
@@ -75,7 +76,7 @@ func Register(ctx context.Context, service string, host Host) *Registration {
 	registration := NewRegistration(ctx, hostUUID, publicCredentialsChan)
 
 	go func() {
-		ticker := time.NewTicker((HEARTBEAT_DURATION - 1) * time.Second)
+		ticker := time.NewTicker(heartbeatTTL - time.Second)
 		defer ticker.Stop()
 
 		// id is the current modification index of the service key.
@@ -202,7 +203,7 @@ func ensureServiceRegistration(ctx context.Context, serviceKey, serviceJSON stri
 }
 
 func hostRegistration(ctx context.Context, hostKey, hostJSON string) error {
-	_, err := KAPI().Set(ctx, hostKey, hostJSON, &etcdv2.SetOptions{TTL: HEARTBEAT_DURATION * time.Second})
+	_, err := KAPI().Set(ctx, hostKey, hostJSON, &etcdv2.SetOptions{TTL: heartbeatTTL})
 	if err != nil {
 		return errors.Wrap(ctx, err, "register host")
 	}

--- a/service/register.go
+++ b/service/register.go
@@ -234,8 +234,9 @@ func ensureHostRegistration(ctx context.Context, service, hostKey, hostJSON stri
 		case <-time.After(1 * time.Second):
 		}
 
-		registrationErr := hostRegistration(ctx, hostKey, hostJSON)
-		if registrationErr == nil {
+		previousErr := err
+		err = hostRegistration(ctx, hostKey, hostJSON)
+		if previousErr != nil && err == nil {
 			log.Infof("Recover registration of '%s'", service)
 		}
 	}

--- a/service/register.go
+++ b/service/register.go
@@ -87,7 +87,7 @@ func Register(ctx context.Context, service string, host Host) *Registration {
 			return
 		}
 
-		err = ensureHostRegistration(ctx, service, hostKey, hostValue, false)
+		err = ensureInitialHostRegistration(ctx, service, hostKey, hostValue, false)
 		if err != nil {
 			registration.signalFailure(err)
 			return
@@ -210,11 +210,15 @@ func hostRegistration(ctx context.Context, hostKey, hostJSON string) error {
 	return nil
 }
 
-// ensureHostRegistration keeps retrying the host registration until it succeeds or the context is canceled.
-func ensureHostRegistration(ctx context.Context, service, hostKey, hostJSON string, logFailures bool) error {
-	ctx, cancel := withDefaultRegistrationTimeout(ctx)
+func ensureInitialHostRegistration(ctx context.Context, service, hostKey, hostJSON string, logFailures bool) error {
+	registrationCtx, cancel := withDefaultRegistrationTimeout(ctx)
 	defer cancel()
 
+	return ensureHostRegistration(registrationCtx, service, hostKey, hostJSON, logFailures)
+}
+
+// ensureHostRegistration keeps retrying the host registration until it succeeds or the context is canceled.
+func ensureHostRegistration(ctx context.Context, service, hostKey, hostJSON string, logFailures bool) error {
 	log := logger.Get(ctx)
 
 	err := hostRegistration(ctx, hostKey, hostJSON)

--- a/service/register.go
+++ b/service/register.go
@@ -239,7 +239,7 @@ func ensureHostRegistration(ctx context.Context, service, hostKey, hostJSON stri
 		}
 
 		err = hostRegistration(ctx, hostKey, hostJSON)
-		if err == nil {
+		if err == nil && logFailures {
 			log.Infof("Recover registration of '%s'", service)
 		}
 	}

--- a/service/register.go
+++ b/service/register.go
@@ -17,6 +17,8 @@ const (
 	// HEARTBEAT_DURATION time in second between two registrations. The host will
 	// be deleted if etcd didn't receive any new registration in those 5 seconds.
 	HEARTBEAT_DURATION = 5
+	// defaultRegistrationTimeout is used when the caller does not provide a deadline on context.
+	defaultRegistrationTimeout = 5 * time.Minute
 )
 
 // Register a host with a service name and a host description. The last chan is
@@ -70,23 +72,23 @@ func Register(ctx context.Context, service string, host Host) *Registration {
 	serviceJSON, _ := json.Marshal(serviceInfos)
 	serviceValue := string(serviceJSON)
 
+	registration := NewRegistration(ctx, hostUUID, publicCredentialsChan)
+
 	go func() {
 		ticker := time.NewTicker((HEARTBEAT_DURATION - 1) * time.Second)
 		defer ticker.Stop()
 
 		// id is the current modification index of the service key.
 		// this is used for the watcher.
-		id, err := serviceRegistration(ctx, serviceKey, serviceValue)
-		for err != nil {
-			if ctx.Err() != nil {
-				return
-			}
-
-			id, err = serviceRegistration(ctx, serviceKey, serviceValue)
+		id, err := ensureServiceRegistration(ctx, serviceKey, serviceValue)
+		if err != nil {
+			registration.signalFailure(err)
+			return
 		}
 
 		err = ensureHostRegistration(ctx, service, hostKey, hostValue, false)
 		if err != nil {
+			registration.signalFailure(err)
 			return
 		}
 
@@ -134,7 +136,7 @@ func Register(ctx context.Context, service string, host Host) *Registration {
 		}
 	}()
 
-	return NewRegistration(ctx, hostUUID, publicCredentialsChan)
+	return registration
 }
 
 func watch(ctx context.Context, serviceKey string, id uint64, credentialsChan chan Credentials) {
@@ -177,6 +179,28 @@ func watch(ctx context.Context, serviceKey string, id uint64, credentialsChan ch
 	}
 }
 
+func ensureServiceRegistration(ctx context.Context, serviceKey, serviceJSON string) (uint64, error) {
+	ctx, cancel := withDefaultRegistrationTimeout(ctx)
+	defer cancel()
+
+	id, err := serviceRegistration(ctx, serviceKey, serviceJSON)
+	for err != nil {
+		if ctx.Err() != nil {
+			return 0, ctx.Err()
+		}
+
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-time.After(1 * time.Second):
+		}
+
+		id, err = serviceRegistration(ctx, serviceKey, serviceJSON)
+	}
+
+	return id, nil
+}
+
 func hostRegistration(ctx context.Context, hostKey, hostJSON string) error {
 	_, err := KAPI().Set(ctx, hostKey, hostJSON, &etcdv2.SetOptions{TTL: HEARTBEAT_DURATION * time.Second})
 	if err != nil {
@@ -187,6 +211,9 @@ func hostRegistration(ctx context.Context, hostKey, hostJSON string) error {
 
 // ensureHostRegistration keeps retrying the host registration until it succeeds or the context is canceled.
 func ensureHostRegistration(ctx context.Context, service, hostKey, hostJSON string, logFailures bool) error {
+	ctx, cancel := withDefaultRegistrationTimeout(ctx)
+	defer cancel()
+
 	log := logger.Get(ctx)
 
 	err := hostRegistration(ctx, hostKey, hostJSON)
@@ -206,13 +233,22 @@ func ensureHostRegistration(ctx context.Context, service, hostKey, hostJSON stri
 		case <-time.After(1 * time.Second):
 		}
 
-		err = hostRegistration(ctx, hostKey, hostJSON)
-		if err == nil && logFailures {
-			log.WithError(err).Errorf("Recover registration of '%s'", service)
+		registrationErr := hostRegistration(ctx, hostKey, hostJSON)
+		if registrationErr == nil {
+			log.Infof("Recover registration of '%s'", service)
 		}
 	}
 
 	return nil
+}
+
+func withDefaultRegistrationTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	_, hasDeadline := ctx.Deadline()
+	if hasDeadline {
+		return ctx, func() {}
+	}
+
+	return context.WithTimeout(ctx, defaultRegistrationTimeout)
 }
 
 func serviceRegistration(ctx context.Context, serviceKey, serviceJSON string) (uint64, error) {

--- a/service/register.go
+++ b/service/register.go
@@ -238,9 +238,8 @@ func ensureHostRegistration(ctx context.Context, service, hostKey, hostJSON stri
 		case <-time.After(1 * time.Second):
 		}
 
-		previousErr := err
 		err = hostRegistration(ctx, hostKey, hostJSON)
-		if previousErr != nil && err == nil {
+		if err == nil {
 			log.Infof("Recover registration of '%s'", service)
 		}
 	}

--- a/service/register_test.go
+++ b/service/register_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"path"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -224,4 +227,125 @@ func TestWithDefaultRegistrationTimeout(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, parentDeadline, deadline)
 	})
+}
+
+func TestEnsureInitialHostRegistration(t *testing.T) {
+	t.Run("It registers the host with the heartbeat TTL", func(t *testing.T) {
+		called := false
+		useFakeEtcdServer(t, func(w http.ResponseWriter, r *http.Request) {
+			called = true
+
+			assert.Equal(t, http.MethodPut, r.Method)
+			assert.Equal(t, "/v2/keys/services/test-initial/host-1", r.URL.Path)
+			require.NoError(t, r.ParseForm())
+			assert.Equal(t, "{}", r.Form.Get("value"))
+			assert.Equal(t, "5", r.Form.Get("ttl"))
+
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(`{"action":"set","node":{"key":"/services/test-initial/host-1","value":"{}","createdIndex":1,"modifiedIndex":1}}`))
+			require.NoError(t, err)
+		})
+
+		err := ensureInitialHostRegistration(
+			t.Context(),
+			"test-initial",
+			"/services/test-initial/host-1",
+			"{}",
+			false,
+		)
+
+		require.NoError(t, err)
+		assert.True(t, called)
+	})
+
+	t.Run("It honors the parent context deadline", func(t *testing.T) {
+		useFakeEtcdServer(t, func(w http.ResponseWriter, _ *http.Request) {
+			writeEtcdError(t, w)
+		})
+
+		ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+		defer cancel()
+
+		err := ensureInitialHostRegistration(
+			ctx,
+			"test-initial-timeout",
+			"/services/test-initial-timeout/host-1",
+			"{}",
+			false,
+		)
+
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+}
+
+func TestEnsureHostRegistrationWaitsForCallerContext(t *testing.T) {
+	firstRequest := make(chan struct{})
+	useFakeEtcdServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case firstRequest <- struct{}{}:
+		default:
+		}
+		writeEtcdError(t, w)
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+
+	go func() {
+		done <- ensureHostRegistration(
+			ctx,
+			"test-heartbeat",
+			"/services/test-heartbeat/host-1",
+			"{}",
+			false,
+		)
+	}()
+
+	select {
+	case <-firstRequest:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the first host registration attempt")
+	}
+
+	select {
+	case err := <-done:
+		t.Fatalf("ensureHostRegistration returned before caller context was canceled: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for ensureHostRegistration to stop after context cancellation")
+	}
+}
+
+func useFakeEtcdServer(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	t.Setenv("ETCD_HOSTS", server.URL)
+
+	previousClient := clientSingleton
+	previousOnce := clientSingletonO
+	clientSingleton = nil
+	clientSingletonO = &sync.Once{}
+
+	t.Cleanup(func() {
+		clientSingleton = previousClient
+		clientSingletonO = previousOnce
+	})
+}
+
+func writeEtcdError(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusInternalServerError)
+	_, err := w.Write([]byte(`{"errorCode":300,"message":"boom","cause":"test","index":1}`))
+	require.NoError(t, err)
 }

--- a/service/register_test.go
+++ b/service/register_test.go
@@ -200,3 +200,28 @@ func TestWatcher(t *testing.T) {
 		})
 	})
 }
+
+func TestWithDefaultRegistrationTimeout(t *testing.T) {
+	t.Run("It adds a default deadline when the parent context has none", func(t *testing.T) {
+		ctx, cancel := withDefaultRegistrationTimeout(t.Context())
+		t.Cleanup(cancel)
+
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok)
+		assert.WithinDuration(t, time.Now().Add(defaultRegistrationTimeout), deadline, 2*time.Second)
+	})
+
+	t.Run("It keeps the parent deadline when one already exists", func(t *testing.T) {
+		parent, parentCancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(parentCancel)
+
+		ctx, cancel := withDefaultRegistrationTimeout(parent)
+		t.Cleanup(cancel)
+
+		parentDeadline, ok := parent.Deadline()
+		require.True(t, ok)
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok)
+		assert.Equal(t, parentDeadline, deadline)
+	})
+}

--- a/service/register_test.go
+++ b/service/register_test.go
@@ -34,7 +34,7 @@ func TestRegister(t *testing.T) {
 			assert.Equal(t, host, *h)
 		})
 
-		t.Run(fmt.Sprintf("And the ttl must be < %s", heartbeatTTL), func(t *testing.T) {
+		t.Run(fmt.Sprintf("And the ttl must be <= %s", heartbeatTTL), func(t *testing.T) {
 			w := Register(t.Context(), "test2_register", host)
 			require.NoError(t, w.WaitRegistration(t.Context()))
 			uuid := w.UUID()

--- a/service/register_test.go
+++ b/service/register_test.go
@@ -237,13 +237,13 @@ func TestEnsureInitialHostRegistration(t *testing.T) {
 
 			assert.Equal(t, http.MethodPut, r.Method)
 			assert.Equal(t, "/v2/keys/services/test-initial/host-1", r.URL.Path)
-			require.NoError(t, r.ParseForm())
+			assert.NoError(t, r.ParseForm())
 			assert.Equal(t, "{}", r.Form.Get("value"))
 			assert.Equal(t, "5", r.Form.Get("ttl"))
 
 			w.Header().Set("Content-Type", "application/json")
 			_, err := w.Write([]byte(`{"action":"set","node":{"key":"/services/test-initial/host-1","value":"{}","createdIndex":1,"modifiedIndex":1}}`))
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		})
 
 		err := ensureInitialHostRegistration(

--- a/service/register_test.go
+++ b/service/register_test.go
@@ -34,7 +34,7 @@ func TestRegister(t *testing.T) {
 			assert.Equal(t, host, *h)
 		})
 
-		t.Run(fmt.Sprintf("And the ttl must be < %d", HEARTBEAT_DURATION), func(t *testing.T) {
+		t.Run(fmt.Sprintf("And the ttl must be < %s", heartbeatTTL), func(t *testing.T) {
 			w := Register(t.Context(), "test2_register", host)
 			require.NoError(t, w.WaitRegistration(t.Context()))
 			uuid := w.UUID()
@@ -45,7 +45,7 @@ func TestRegister(t *testing.T) {
 
 			now := time.Now()
 			duration := res.Node.Expiration.Sub(now)
-			assert.LessOrEqual(t, duration, HEARTBEAT_DURATION*time.Second)
+			assert.LessOrEqual(t, duration, heartbeatTTL)
 		})
 
 		t.Run("And the service infos must be set", func(t *testing.T) {
@@ -128,7 +128,7 @@ func TestRegister(t *testing.T) {
 			assert.Eventually(t, func() bool {
 				_, err := KAPI().Get(t.Context(), hostKey, &etcdv2.GetOptions{})
 				return etcdv2.IsKeyNotFound(err)
-			}, (HEARTBEAT_DURATION+2)*time.Second, 100*time.Millisecond)
+			}, heartbeatTTL+2*time.Second, 100*time.Millisecond)
 		})
 
 		t.Run("When the private_hostname is not set, it must take the node hostname", func(t *testing.T) {

--- a/service/registration.go
+++ b/service/registration.go
@@ -17,6 +17,7 @@ type RegistrationWrapper interface {
 // Registration is the RegistrationWrapper implementation used by the Register method
 type Registration struct {
 	credChan        chan Credentials
+	failureChan     chan error
 	readyChan       chan struct{}
 	ready           bool
 	waitErr         error
@@ -30,6 +31,7 @@ type Registration struct {
 func NewRegistration(ctx context.Context, uuid string, cred chan Credentials) *Registration {
 	r := &Registration{
 		credChan:        cred,
+		failureChan:     make(chan error, 1),
 		readyChan:       make(chan struct{}),
 		ready:           false,
 		waitErr:         nil,
@@ -93,6 +95,9 @@ func (w *Registration) worker(ctx context.Context) {
 			// Unblock WaitRegistration callers even if the registration never reached etcd.
 			w.signalReady(ctx.Err())
 			return
+		case err := <-w.failureChan:
+			w.signalReady(err)
+			return
 		case newCred := <-w.credChan:
 			w.mutex.Lock()
 			w.curCredentials = &newCred
@@ -116,4 +121,15 @@ func (w *Registration) signalReady(err error) {
 		w.mutex.Unlock()
 		close(w.readyChan)
 	})
+}
+
+func (w *Registration) signalFailure(err error) {
+	if err == nil {
+		return
+	}
+
+	select {
+	case w.failureChan <- err:
+	default:
+	}
 }

--- a/service/registration_test.go
+++ b/service/registration_test.go
@@ -64,7 +64,7 @@ func TestWaitRegistration(t *testing.T) {
 		assert.False(t, order[1])
 	})
 
-	t.Run("It must return an error when the context deadline exceeded", func(t *testing.T) {
+	t.Run("It must return an error when the context deadline is exceeded", func(t *testing.T) {
 		r := NewRegistration(t.Context(), "1234", make(chan Credentials))
 		r.signalFailure(context.DeadlineExceeded)
 

--- a/service/registration_test.go
+++ b/service/registration_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -61,6 +62,15 @@ func TestWaitRegistration(t *testing.T) {
 
 		assert.True(t, order[0])
 		assert.False(t, order[1])
+	})
+
+	t.Run("It must return an error when the context deadline exceeded", func(t *testing.T) {
+		r := NewRegistration(t.Context(), "1234", make(chan Credentials))
+		r.signalFailure(context.DeadlineExceeded)
+
+		err := r.WaitRegistration(t.Context())
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.False(t, r.Ready())
 	})
 }
 


### PR DESCRIPTION
Fix #170 