### PR TITLE
feat(register): Add logs when service and host is registered on etcd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * refactor: Replace `errgo` by `github.com/Scalingo/go-utils/errors/v3`
 * refactor: Replace std logger by `github.com/Scalingo/go-utils/logger`
 * fix(service): Avoid an infinite wait on registrations by timing out after 5 minutes
+* feat(register): Add logs when service and host is registered on etcd
 
 Breaking Changes:
 * Public functions and methods that previously had no `context.Context` parameter now require one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * refactor: Replace std logger by `github.com/Scalingo/go-utils/logger`
 * fix(service): Avoid an infinite wait on registrations by timing out after 5 minutes
 * feat(register): Add logs when service and host is registered on etcd
+* feat(registration): Add a log when waiting for etcd registration
 
 Breaking Changes:
 * Public functions and methods that previously had no `context.Context` parameter now require one

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Scalingo/go-utils/errors/v3 v3.2.1
 	github.com/Scalingo/go-utils/logger v1.12.2
 	github.com/gofrs/uuid/v5 v5.4.0
+	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
 	go.etcd.io/etcd/client/pkg/v3 v3.6.10
 	// The latest versions of etcd have been migrated to go modules.
@@ -28,7 +29,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/sirupsen/logrus v1.9.4 // indirect
 	go.etcd.io/etcd/api/v3 v3.6.10 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,5 +64,7 @@ gopkg.in/errgo.v1 v1.0.1 h1:oQFRXzZ7CkBGdm1XZm/EbQYaYNNEElNBOd09M6cqNso=
 gopkg.in/errgo.v1 v1.0.1/go.mod h1:3NjfXwocQRYAPTq4/fzX+CwUhPRcR/azYRhj8G+LqMo=
 gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 h1:VpOs+IwYnYBaFnrNAeB8UUWtL3vEUnzSCL1nVjPhqrw=
 gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/service/register.go
+++ b/service/register.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid/v5"
+	"github.com/sirupsen/logrus"
 	etcdv2 "go.etcd.io/etcd/client/v2"
 
 	"github.com/Scalingo/go-utils/errors/v3"
@@ -30,8 +31,6 @@ const (
 // registration every 5 seconds, and the second one will check if the service
 // credentials don't change and notify otherwise.
 func Register(ctx context.Context, service string, host Host) *Registration {
-	log := logger.Get(ctx)
-
 	if !host.Public && len(host.PrivateHostname) == 0 {
 		host.PrivateHostname = host.Hostname
 	}
@@ -44,6 +43,11 @@ func Register(ctx context.Context, service string, host Host) *Registration {
 	if len(host.PrivateHostname) != 0 && len(host.PrivatePorts) == 0 {
 		host.PrivatePorts = host.Ports
 	}
+
+	ctx, log := logger.WithFieldsToCtx(ctx, logrus.Fields{
+		"hostname":     host.Hostname,
+		"service_name": host.Name,
+	})
 
 	uuidV4, _ := uuid.NewV4()
 	hostUUID := fmt.Sprintf("%s-%s", uuidV4.String(), host.PrivateHostname)
@@ -86,12 +90,14 @@ func Register(ctx context.Context, service string, host Host) *Registration {
 			registration.signalFailure(err)
 			return
 		}
+		log.Info("Service registered in etcd")
 
 		err = ensureInitialHostRegistration(ctx, service, hostKey, hostValue, false)
 		if err != nil {
 			registration.signalFailure(err)
 			return
 		}
+		log.Info("Host registered in etcd")
 
 		publicCredentialsChan <- Credentials{
 			User:     serviceInfos.User,

--- a/service/registration.go
+++ b/service/registration.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	stderrors "errors"
 	"sync"
+
+	"github.com/Scalingo/go-utils/logger"
 )
 
 // RegistrationWrapper wraps the uuid and the credential channel to provide a more user-friendly API for the Register Method
@@ -50,6 +52,9 @@ func (w *Registration) WaitRegistration(ctx context.Context) error {
 	if w.Ready() {
 		return nil
 	}
+
+	log := logger.Get(ctx)
+	log.Info("Waiting for etcd registration")
 
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
Fix #173

Small addition to give more visibility on what is happening when a service start.

Result:
```bash
[2026-04-29T13:22:04.956863432Z] app-scheduler | [00] INFO[2026-04-29T13:22:04.956] Waiting for etcd registration                 port=11111 scheme=http service_name=app-scheduler
[2026-04-29T13:22:04.966810509Z] app-scheduler | [00] INFO[2026-04-29T13:22:04.966] Service registered in etcd                    hostname=172.17.0.1 port=11111 scheme=http service_name=app-scheduler
[2026-04-29T13:22:04.970185834Z] app-scheduler | [00] INFO[2026-04-29T13:22:04.969] Host registered in etcd                       hostname=172.17.0.1 port=11111 scheme=http service_name=app-scheduler
```

> [!NOTE]
> `port` and  `scheme` fields was added by the scheduler service, not by the current package